### PR TITLE
Stop recreating SynBioHub objects

### DIFF
--- a/SBOLCanvasBackend/src/data/CanvasAnnotation.java
+++ b/SBOLCanvasBackend/src/data/CanvasAnnotation.java
@@ -1,0 +1,112 @@
+package data;
+
+import java.net.URI;
+
+import javax.xml.namespace.QName;
+
+public class CanvasAnnotation {
+
+	private String namespaceURI;
+	private String localPart;
+	private String prefix;
+	private String nestedNamespaceURI;
+	private String nestedLocalPart;
+	private String nestedPrefix;
+	private URI nestedURI;
+	private String stringValue;
+	private URI uriValue;
+	private CanvasAnnotation[] annotations;
+
+	public void setQName(QName qname) {
+		this.namespaceURI = qname.getNamespaceURI();
+		this.localPart = qname.getLocalPart();
+		this.prefix = qname.getPrefix();
+	}
+	
+	public void setNestedQName(QName nestedQName) {
+		this.nestedNamespaceURI = nestedQName.getNamespaceURI();
+		this.nestedLocalPart = nestedQName.getLocalPart();
+		this.nestedPrefix = nestedQName.getPrefix();
+	}
+	
+	public String getNamespaceURI() {
+		return namespaceURI;
+	}
+
+	public void setNamespaceURI(String namespaceURI) {
+		this.namespaceURI = namespaceURI;
+	}
+
+	public String getLocalPart() {
+		return localPart;
+	}
+
+	public void setLocalPart(String localPart) {
+		this.localPart = localPart;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getNestedNamespaceURI() {
+		return nestedNamespaceURI;
+	}
+
+	public void setNestedNamespaceURI(String nestedNamespaceURI) {
+		this.nestedNamespaceURI = nestedNamespaceURI;
+	}
+
+	public String getNestedLocalPart() {
+		return nestedLocalPart;
+	}
+
+	public void setNestedLocalPart(String nestedLocalPart) {
+		this.nestedLocalPart = nestedLocalPart;
+	}
+
+	public String getNestedPrefix() {
+		return nestedPrefix;
+	}
+
+	public void setNestedPrefix(String nestedPrefix) {
+		this.nestedPrefix = nestedPrefix;
+	}
+	
+	public URI getNestedURI() {
+		return this.nestedURI;
+	}
+	
+	public void setNestedURI(URI nestedURI) {
+		this.nestedURI = nestedURI;
+	}
+	
+	public String getStringValue() {
+		return stringValue;
+	}
+
+	public void setStringValue(String stringValue) {
+		this.stringValue = stringValue;
+	}
+
+	public URI getUriValue() {
+		return uriValue;
+	}
+
+	public void setUriValue(URI uriValue) {
+		this.uriValue = uriValue;
+	}
+
+	public CanvasAnnotation[] getAnnotations() {
+		return annotations;
+	}
+
+	public void setAnnotations(CanvasAnnotation[] annotations) {
+		this.annotations = annotations;
+	}
+
+}

--- a/SBOLCanvasBackend/src/data/GlyphInfo.java
+++ b/SBOLCanvasBackend/src/data/GlyphInfo.java
@@ -1,5 +1,7 @@
 package data;
 
+import java.net.URI;
+
 public class GlyphInfo extends Info {
 
 	private String partType;
@@ -14,6 +16,8 @@ public class GlyphInfo extends Info {
 	private String sequence;
 	private String uriPrefix;
 	private CanvasAnnotation[] annotations;
+	private URI[] derivedFroms;
+	private URI[] generatedBys;
 
 	public String getUriPrefix() {
 		return uriPrefix;
@@ -109,6 +113,22 @@ public class GlyphInfo extends Info {
 
 	public void setAnnotations(CanvasAnnotation[] annotations) {
 		this.annotations = annotations;
+	}
+	
+	public URI[] getDerivedFroms() {
+		return derivedFroms;
+	}
+
+	public void setDerivedFroms(URI[] derivedFroms) {
+		this.derivedFroms = derivedFroms;
+	}
+
+	public URI[] getGeneratedBys() {
+		return generatedBys;
+	}
+
+	public void setGeneratedBys(URI[] generatedBys) {
+		this.generatedBys = generatedBys;
 	}
 	
 	public String getFullURI() {

--- a/SBOLCanvasBackend/src/data/GlyphInfo.java
+++ b/SBOLCanvasBackend/src/data/GlyphInfo.java
@@ -1,7 +1,5 @@
 package data;
 
-import java.net.URI;
-
 public class GlyphInfo extends Info {
 
 	private String partType;

--- a/SBOLCanvasBackend/src/data/GlyphInfo.java
+++ b/SBOLCanvasBackend/src/data/GlyphInfo.java
@@ -14,10 +14,11 @@ public class GlyphInfo extends Info {
 	private String description;
 	private String version;
 	private String sequence;
+	private String sequenceURI;
 	private String uriPrefix;
 	private CanvasAnnotation[] annotations;
-	private URI[] derivedFroms;
-	private URI[] generatedBys;
+	private String[] derivedFroms;
+	private String[] generatedBys;
 
 	public String getUriPrefix() {
 		return uriPrefix;
@@ -107,6 +108,14 @@ public class GlyphInfo extends Info {
 		this.sequence = sequence;
 	}
 	
+	public String getSequenceURI() {
+		return sequenceURI;
+	}
+
+	public void setSequenceURI(String sequenceURI) {
+		this.sequenceURI = sequenceURI;
+	}
+	
 	public CanvasAnnotation[] getAnnotations() {
 		return annotations;
 	}
@@ -115,19 +124,19 @@ public class GlyphInfo extends Info {
 		this.annotations = annotations;
 	}
 	
-	public URI[] getDerivedFroms() {
+	public String[] getDerivedFroms() {
 		return derivedFroms;
 	}
 
-	public void setDerivedFroms(URI[] derivedFroms) {
+	public void setDerivedFroms(String[] derivedFroms) {
 		this.derivedFroms = derivedFroms;
 	}
 
-	public URI[] getGeneratedBys() {
+	public String[] getGeneratedBys() {
 		return generatedBys;
 	}
 
-	public void setGeneratedBys(URI[] generatedBys) {
+	public void setGeneratedBys(String[] generatedBys) {
 		this.generatedBys = generatedBys;
 	}
 	

--- a/SBOLCanvasBackend/src/data/GlyphInfo.java
+++ b/SBOLCanvasBackend/src/data/GlyphInfo.java
@@ -1,8 +1,5 @@
 package data;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
 public class GlyphInfo extends Info {
 
 	private String partType;
@@ -16,6 +13,7 @@ public class GlyphInfo extends Info {
 	private String version;
 	private String sequence;
 	private String uriPrefix;
+	private CanvasAnnotation[] annotations;
 
 	public String getUriPrefix() {
 		return uriPrefix;
@@ -105,36 +103,19 @@ public class GlyphInfo extends Info {
 		this.sequence = sequence;
 	}
 	
+	public CanvasAnnotation[] getAnnotations() {
+		return annotations;
+	}
+
+	public void setAnnotations(CanvasAnnotation[] annotations) {
+		this.annotations = annotations;
+	}
+	
 	public String getFullURI() {
 		String fullURI = this.uriPrefix + '/' + this.displayID;
 		if(this.version != null && this.version.length() > 0) {
 			fullURI += '/' + this.version;
 		}
 		return fullURI;
-	}
-	
-	@Override
-	public Element encode(Document doc) {
-		Element glyphInfo = doc.createElement("GlyphInfo");
-		if (description != null)
-			glyphInfo.setAttribute("description", description);
-		if (displayID != null)
-			glyphInfo.setAttribute("displayID", displayID);
-		if (name != null)
-			glyphInfo.setAttribute("name", name);
-		if (partRefine != null)
-			glyphInfo.setAttribute("partRefine", partRefine);
-		if (partRole != null)
-			glyphInfo.setAttribute("partRole", partRole);
-		if (partType != null)
-			glyphInfo.setAttribute("partType", partType);
-		if (sequence != null)
-			glyphInfo.setAttribute("sequence", sequence);
-		if (version != null)
-			glyphInfo.setAttribute("version", version);
-		if (uriPrefix != null)
-			glyphInfo.setAttribute("uriPrefix", uriPrefix);
-		glyphInfo.setAttribute("as", "data");
-		return glyphInfo;
 	}
 }

--- a/SBOLCanvasBackend/src/data/Info.java
+++ b/SBOLCanvasBackend/src/data/Info.java
@@ -1,10 +1,5 @@
 package data;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
 public abstract class Info {
-
-	public abstract Element encode(Document doc);
 	
 }

--- a/SBOLCanvasBackend/src/data/InteractionInfo.java
+++ b/SBOLCanvasBackend/src/data/InteractionInfo.java
@@ -1,8 +1,5 @@
 package data;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
 public class InteractionInfo extends Info {
 
 	private String displayID;

--- a/SBOLCanvasBackend/src/data/InteractionInfo.java
+++ b/SBOLCanvasBackend/src/data/InteractionInfo.java
@@ -8,6 +8,7 @@ public class InteractionInfo extends Info {
 	private String displayID;
 	private String interactionType;
 	private String fromParticipationType;
+	private String toParticipationType;
 
 	public String getDisplayID() {
 		return displayID;
@@ -40,18 +41,4 @@ public class InteractionInfo extends Info {
 	public void setToParticipationType(String toParticipationType) {
 		this.toParticipationType = toParticipationType;
 	}
-
-	private String toParticipationType;
-
-	@Override
-	public Element encode(Document doc) {
-		Element intInfo = doc.createElement("InteractionInfo");
-		if (displayID != null)
-			intInfo.setAttribute("displayID", displayID);
-		if (interactionType != null)
-			intInfo.setAttribute("interactionType", interactionType);
-		intInfo.setAttribute("as", "data");
-		return intInfo;
-	}
-
 }

--- a/SBOLCanvasBackend/src/servlets/Convert.java
+++ b/SBOLCanvasBackend/src/servlets/Convert.java
@@ -18,6 +18,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.sbolstandard.core2.SBOLConversionException;
 import org.sbolstandard.core2.SBOLValidationException;
+import org.synbiohub.frontend.SynBioHubException;
 import org.xml.sax.SAXException;
 
 import utils.MxToSBOL;
@@ -47,7 +48,7 @@ public class Convert extends HttpServlet {
 
 			response.setStatus(HttpStatus.SC_OK);
 		} catch (SBOLValidationException | IOException | SBOLConversionException | ParserConfigurationException
-				| TransformerException | SAXException | TransformerFactoryConfigurationError | URISyntaxException e) {
+				| TransformerException | SAXException | TransformerFactoryConfigurationError | URISyntaxException | SynBioHubException e) {
 			ServletOutputStream outputStream = response.getOutputStream();
 			InputStream inputStream = new ByteArrayInputStream(e.getMessage().getBytes());
 			IOUtils.copy(inputStream, outputStream);

--- a/SBOLCanvasBackend/src/servlets/SynBioHub.java
+++ b/SBOLCanvasBackend/src/servlets/SynBioHub.java
@@ -255,7 +255,7 @@ public class SynBioHub extends HttpServlet {
 				}
 				SynBioHubFrontend sbhf = new SynBioHubFrontend(server);
 				sbhf.setUser(user);
-				MxToSBOL converter = new MxToSBOL();
+				MxToSBOL converter = new MxToSBOL(user);
 				ByteArrayOutputStream out = new ByteArrayOutputStream();
 				converter.toSBOL(request.getInputStream(), out, name);
 				sbhf.addToCollection(URI.create(uri), true, new ByteArrayInputStream(out.toByteArray()));

--- a/SBOLCanvasBackend/src/utils/Converter.java
+++ b/SBOLCanvasBackend/src/utils/Converter.java
@@ -1,19 +1,15 @@
 package utils;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Set;
 
 import javax.xml.namespace.QName;
 
-import org.sbolstandard.core2.Annotation;
 import org.sbolstandard.core2.SystemsBiologyOntology;
 
 import com.mxgraph.io.mxCodecRegistry;
 
-import data.CanvasAnnotation;
 import data.GlyphInfo;
 
 public class Converter {

--- a/SBOLCanvasBackend/src/utils/Converter.java
+++ b/SBOLCanvasBackend/src/utils/Converter.java
@@ -1,15 +1,19 @@
 package utils;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Set;
 
 import javax.xml.namespace.QName;
 
+import org.sbolstandard.core2.Annotation;
 import org.sbolstandard.core2.SystemsBiologyOntology;
 
 import com.mxgraph.io.mxCodecRegistry;
 
+import data.CanvasAnnotation;
 import data.GlyphInfo;
 
 public class Converter {
@@ -60,6 +64,6 @@ public class Converter {
 	static QName createQName(String name) {
 		return new QName(URI_PREFIX, name, ANN_PREFIX);
 	}
-
+	
 	// helpers
 }

--- a/SBOLCanvasBackend/src/utils/MxToSBOL.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBOL.java
@@ -301,9 +301,10 @@ public class MxToSBOL extends Converter {
 
 		// component sequence
 		if (glyphInfo.getSequence() != null && !glyphInfo.getSequence().equals("")) {
-			Sequence seq = document.createSequence(compDef.getDisplayId() + "_sequence", glyphInfo.getSequence(),
+			Sequence sequence = document.createSequence(compDef.getDisplayId() + "_sequence", glyphInfo.getSequence(),
 					Sequence.IUPAC_DNA);
-			compDef.addSequence(seq.getIdentity());
+//			if(glyphInfo.getSequenceURI() != null && !glyphInfo.getUriPrefix().equals(Converter.URI_PREFIX))
+//				compDef.addSequence(URI.create(glyphInfo.getSequenceURI()));
 		}
 
 		if (glyphInfo.getAnnotations() != null) {
@@ -311,16 +312,17 @@ public class MxToSBOL extends Converter {
 		}
 		
 		if(glyphInfo.getDerivedFroms() != null) {
-			for(URI derivedFrom : glyphInfo.getDerivedFroms()) {
-				compDef.addWasDerivedFrom(derivedFrom);
+			for(String derivedFrom : glyphInfo.getDerivedFroms()) {
+				compDef.addWasDerivedFrom(URI.create(derivedFrom));
 			}
 		}
 		
-		if(glyphInfo.getGeneratedBys() != null) {
-			for(URI generatedBy : glyphInfo.getGeneratedBys()) {
-				compDef.addWasGeneratedBy(generatedBy);
-			}
-		}
+		//TODO come back to me when the activity objects are round tripping
+//		if(glyphInfo.getGeneratedBys() != null) {
+//			for(String generatedBy : glyphInfo.getGeneratedBys()) {
+//				compDef.addWasGeneratedBy(URI.create(generatedBy));
+//			}
+//		}
 
 		// store extra mxGraph information
 		Object[] containerChildren = mxGraphModel.getChildCells(model, circuitContainer, true, false);

--- a/SBOLCanvasBackend/src/utils/SBOLData.java
+++ b/SBOLCanvasBackend/src/utils/SBOLData.java
@@ -3,12 +3,16 @@ package utils;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.sbolstandard.core2.ComponentDefinition;
 import org.sbolstandard.core2.SequenceOntology;
 import org.sbolstandard.core2.SystemsBiologyOntology;
+import org.synbiohub.frontend.SynBioHubException;
+import org.synbiohub.frontend.SynBioHubFrontend;
+import org.synbiohub.frontend.WebOfRegistriesData;
 
 public class SBOLData {
 
@@ -19,6 +23,8 @@ public class SBOLData {
 	public static BiMap<String, URI> refinements;
 	public static HashMap<URI, URI> parents;
 	public static BiMap<String, URI> interactions;
+	public static HashSet<String> registries;
+	
 	
 	static {
 		so = new SequenceOntology();
@@ -86,6 +92,15 @@ public class SBOLData {
 		interactions.put("Degradation", SystemsBiologyOntology.DEGRADATION);
 		interactions.put("Genetic Production", SystemsBiologyOntology.GENETIC_PRODUCTION);
 		interactions.put("Control", SystemsBiologyOntology.CONTROL);
+		
+		registries = new HashSet<String>();
+		try {
+			for(WebOfRegistriesData registry : SynBioHubFrontend.getRegistries()) {
+				registries.add(registry.getInstanceUrl());
+			}
+		} catch (SynBioHubException e) {
+			e.printStackTrace();
+		}
 		
 	}
 	

--- a/SBOLCanvasBackend/src/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/utils/SBOLToMx.java
@@ -85,6 +85,19 @@ public class SBOLToMx extends Converter {
 			modDef = document.getRootModuleDefinitions().iterator().next();
 		}
 
+		// scan through components to ensure we have the correct registries set up
+		for(ComponentDefinition compDef : document.getComponentDefinitions()) {
+			for(Component comp : compDef.getComponents()) {
+				for(String registry : SBOLData.registries) {
+					if(comp.getDefinitionURI().toString().contains(registry)) {
+						document.addRegistry(registry);
+						document.getComponentDefinition(comp.getDefinitionURI());
+						break;
+					}
+				}
+			}
+		}
+		
 		// top level component definitions
 		Set<ComponentDefinition> compDefs = document.getComponentDefinitions();
 		Set<ComponentDefinition> handledCompDefs = new HashSet<ComponentDefinition>();

--- a/SBOLCanvasBackend/src/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/utils/SBOLToMx.java
@@ -434,6 +434,14 @@ public class SBOLToMx extends Converter {
 			lastIndex = identity.lastIndexOf(glyphInfo.getDisplayID());
 		glyphInfo.setUriPrefix(identity.substring(0, lastIndex - 1));
 		
+		if(glyphCD.getWasDerivedFroms() != null && glyphCD.getWasDerivedFroms().size() > 0) {
+			glyphInfo.setDerivedFroms(glyphCD.getWasDerivedFroms().toArray(new URI[0]));
+		}
+		
+		if(glyphCD.getWasGeneratedBys() != null && glyphCD.getWasGeneratedBys().size() > 0) {
+			glyphInfo.setGeneratedBys(glyphCD.getWasGeneratedBys().toArray(new URI[0]));
+		}
+		
 		glyphInfo.setAnnotations(convertSBOLAnnotations(glyphCD.getAnnotations()));
 		return glyphInfo;
 	}

--- a/SBOLCanvasBackend/src/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/utils/SBOLToMx.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -36,6 +37,7 @@ import org.sbolstandard.core2.SBOLConversionException;
 import org.sbolstandard.core2.SBOLDocument;
 import org.sbolstandard.core2.SBOLReader;
 import org.sbolstandard.core2.SBOLValidationException;
+import org.sbolstandard.core2.Sequence;
 import org.sbolstandard.core2.SequenceAnnotation;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
@@ -423,8 +425,11 @@ public class SBOLToMx extends Converter {
 		}
 		glyphInfo.setOtherTypes(otherTypes.toArray(new String[0]));
 
-		if (glyphCD.getSequences().size() > 0)
-			glyphInfo.setSequence(glyphCD.getSequences().iterator().next().getElements());
+		if (glyphCD.getSequences().size() > 0) {
+			Sequence sequence = glyphCD.getSequences().iterator().next();
+			glyphInfo.setSequence(sequence.getElements());
+			glyphInfo.setSequenceURI(sequence.getIdentity().toString());
+		}
 		glyphInfo.setVersion(glyphCD.getVersion());
 		String identity = glyphCD.getIdentity().toString();
 		int lastIndex = 0;
@@ -435,11 +440,23 @@ public class SBOLToMx extends Converter {
 		glyphInfo.setUriPrefix(identity.substring(0, lastIndex - 1));
 		
 		if(glyphCD.getWasDerivedFroms() != null && glyphCD.getWasDerivedFroms().size() > 0) {
-			glyphInfo.setDerivedFroms(glyphCD.getWasDerivedFroms().toArray(new URI[0]));
+			String[] derivedFroms = new String[glyphCD.getWasDerivedFroms().size()];
+			int index = 0;
+			for(URI derivedFrom : glyphCD.getWasDerivedFroms()) {
+				derivedFroms[index] = derivedFrom.toString();
+				index++;
+			}
+			glyphInfo.setDerivedFroms(derivedFroms);
 		}
 		
 		if(glyphCD.getWasGeneratedBys() != null && glyphCD.getWasGeneratedBys().size() > 0) {
-			glyphInfo.setGeneratedBys(glyphCD.getWasGeneratedBys().toArray(new URI[0]));
+			String[] generatedBys = new String[glyphCD.getWasGeneratedBys().size()];
+			int index = 0;
+			for(URI generatedBy : glyphCD.getWasGeneratedBys()) {
+				generatedBys[index] = generatedBy.toString();
+				index++;
+			}
+			glyphInfo.setGeneratedBys(generatedBys);
 		}
 		
 		glyphInfo.setAnnotations(convertSBOLAnnotations(glyphCD.getAnnotations()));

--- a/SBOLCanvasBackend/src/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/utils/SBOLToMx.java
@@ -7,7 +7,6 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;

--- a/SBOLCanvasFrontend/package-lock.json
+++ b/SBOLCanvasFrontend/package-lock.json
@@ -1726,7 +1726,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -7279,7 +7279,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {

--- a/SBOLCanvasFrontend/src/app/canvasAnnotation.ts
+++ b/SBOLCanvasFrontend/src/app/canvasAnnotation.ts
@@ -1,0 +1,62 @@
+
+export class CanvasAnnotation {
+  namespaceURI: string;
+  localPart: string;
+  prefix: string;
+  nestedNamespaceURI: string;
+  nestedLocalPart: string;
+  nestedPrefix: string;
+  nestedURI: string;
+  stringValue: string;
+  uriValue: string;
+  annotations: CanvasAnnotation[];
+
+  decode(dec, node, into) {
+    const meta = node;
+    if (meta != null) {
+      for (let i = 0; i < meta.attributes.length; i++) {
+        const attrib = meta.attributes[i];
+        if (attrib.specified == true && attrib.name != 'as') {
+          this[attrib.name] = attrib.value;
+        }
+      }
+      for (let i = 0; i < meta.children.length; i++) {
+        const childNode = meta.children[i];
+        if (childNode.getAttribute("as") === "annotations") {
+          this.annotations = dec.decode(childNode);
+        }
+      }
+    }
+    return this;
+  }
+
+  encode(enc: any) {
+    let node = enc.document.createElement('CanvasAnnotation');
+    if (this.namespaceURI)
+      node.setAttribute("namespaceURI", this.namespaceURI);
+    if (this.localPart)
+      node.setAttribute("localPart", this.localPart);
+    if (this.prefix)
+      node.setAttribute("prefix", this.prefix);
+    if(this.nestedNamespaceURI)
+      node.setAttribute("nestedNamespaceURI", this.nestedNamespaceURI);
+    if(this.nestedLocalPart)
+      node.setAttribute("nestedLocalPart", this.nestedLocalPart);
+    if(this.nestedPrefix)
+      node.setAttribute("nestedPrefix", this.nestedPrefix);
+    if(this.nestedURI) 
+      node.setAttribute("nestedURI", this.nestedURI);
+    if (this.stringValue)
+      node.setAttribute("stringValue", this.stringValue);
+    if (this.uriValue)
+      node.setAttribute("uriValue", this.uriValue);
+    if (this.annotations) {
+      let annotationsNode = enc.encode(this.annotations);
+      annotationsNode.setAttribute("as", "annotations");
+      node.appendChild(annotationsNode);
+    }
+
+    return node;
+  }
+
+}

--- a/SBOLCanvasFrontend/src/app/canvasAnnotation.ts
+++ b/SBOLCanvasFrontend/src/app/canvasAnnotation.ts
@@ -11,25 +11,6 @@ export class CanvasAnnotation {
   uriValue: string;
   annotations: CanvasAnnotation[];
 
-  decode(dec, node, into) {
-    const meta = node;
-    if (meta != null) {
-      for (let i = 0; i < meta.attributes.length; i++) {
-        const attrib = meta.attributes[i];
-        if (attrib.specified == true && attrib.name != 'as') {
-          this[attrib.name] = attrib.value;
-        }
-      }
-      for (let i = 0; i < meta.children.length; i++) {
-        const childNode = meta.children[i];
-        if (childNode.getAttribute("as") === "annotations") {
-          this.annotations = dec.decode(childNode);
-        }
-      }
-    }
-    return this;
-  }
-
   encode(enc: any) {
     let node = enc.document.createElement('CanvasAnnotation');
     if (this.namespaceURI)

--- a/SBOLCanvasFrontend/src/app/files.service.ts
+++ b/SBOLCanvasFrontend/src/app/files.service.ts
@@ -44,25 +44,32 @@ export class FilesService {
     return this.http.get(this.loadFilesURL, { responseType: 'text', params: params });
   }
 
-  loadLocal(file: File, graphService: GraphService) {
-    if (typeof (FileReader) !== 'undefined') {
-      const reader = new FileReader();
-
-      reader.onload = (e: any) => {
-        this.convertToMxGraph(String(reader.result)).subscribe(result => {
-          graphService.setGraphToXML(result);
-        });
-      };
-
-      reader.readAsText(file);
-    }
-
+  loadLocal(file: File, graphService: GraphService): Observable<void>{
+    return new Observable<void>( observer => {
+      if (typeof (FileReader) !== 'undefined') {
+        const reader = new FileReader();
+  
+        reader.onload = (e: any) => {
+          this.convertToMxGraph(String(reader.result)).subscribe(result => {
+            graphService.setGraphToXML(result);
+            observer.next();
+          });
+        };
+  
+        reader.readAsText(file);
+      }else{
+        observer.next();
+      }
+    });
   }
 
-  saveLocal(filename: string, contents: string) {
-    this.convertToSBOL(contents, filename).subscribe(result => {
-      var file = new File([result], filename + ".xml", { type: 'text/plain;charset=utf-8' });
-      FileSaver.saveAs(file);
+  saveLocal(filename: string, contents: string): Observable<void> {
+    return new Observable<void>( observer => {
+      this.convertToSBOL(contents, filename).subscribe(result => {
+        var file = new File([result], filename + ".xml", { type: 'text/plain;charset=utf-8' });
+        FileSaver.saveAs(file);
+        observer.next();
+      });
     });
   }
 

--- a/SBOLCanvasFrontend/src/app/glyphInfo.ts
+++ b/SBOLCanvasFrontend/src/app/glyphInfo.ts
@@ -15,6 +15,7 @@ export class GlyphInfo {
   description: string;
   version: string;
   sequence: string;
+  sequenceURI: string;
   uriPrefix: string = GlyphInfo.baseURI;
   annotations: CanvasAnnotation[];
   derivedFroms: string[];
@@ -41,6 +42,7 @@ export class GlyphInfo {
     copy.description = this.description;
     copy.version = this.version;
     copy.sequence = this.sequence;
+    copy.sequenceURI = this.sequenceURI;
     copy.uriPrefix = this.uriPrefix;
     copy.annotations = this.annotations ? this.annotations.slice() : null;
     copy.derivedFroms = this.derivedFroms ? this.derivedFroms.slice() : null;
@@ -59,6 +61,7 @@ export class GlyphInfo {
     this.description = other.description;
     this.version = other.version;
     this.sequence = other.sequence;
+    this.sequenceURI = other.sequenceURI;
     this.uriPrefix = other.uriPrefix;
     this.annotations = other.annotations ? other.annotations.slice() : null;
     this.derivedFroms = other.derivedFroms ? other.derivedFroms.slice() : null;
@@ -101,6 +104,8 @@ export class GlyphInfo {
       node.setAttribute("version", this.version);
     if (this.sequence && this.sequence.length > 0)
       node.setAttribute("sequence", this.sequence);
+    if(this.sequenceURI && this.sequenceURI.length > 0)
+      node.setAttribute("sequenceURI", this.sequenceURI);
     if (this.uriPrefix)
       node.setAttribute("uriPrefix", this.uriPrefix);
 

--- a/SBOLCanvasFrontend/src/app/glyphInfo.ts
+++ b/SBOLCanvasFrontend/src/app/glyphInfo.ts
@@ -17,6 +17,8 @@ export class GlyphInfo {
   sequence: string;
   uriPrefix: string = GlyphInfo.baseURI;
   annotations: CanvasAnnotation[];
+  derivedFroms: string[];
+  generatedBys: string[];
 
   constructor(partType?: string) {
     this.displayID = 'id' + (GlyphInfo.counter++);
@@ -41,6 +43,8 @@ export class GlyphInfo {
     copy.sequence = this.sequence;
     copy.uriPrefix = this.uriPrefix;
     copy.annotations = this.annotations ? this.annotations.slice() : null;
+    copy.derivedFroms = this.derivedFroms ? this.derivedFroms.slice() : null;
+    copy.generatedBys = this.generatedBys ? this.generatedBys.slice() : null;
     return copy;
   }
 
@@ -56,7 +60,9 @@ export class GlyphInfo {
     this.version = other.version;
     this.sequence = other.sequence;
     this.uriPrefix = other.uriPrefix;
-    this.annotations = other.annotations.slice();
+    this.annotations = other.annotations ? other.annotations.slice() : null;
+    this.derivedFroms = other.derivedFroms ? other.derivedFroms.slice() : null;
+    this.generatedBys = other.generatedBys ? other.generatedBys.slice() : null;
   }
 
   getFullURI(): string {
@@ -65,29 +71,6 @@ export class GlyphInfo {
       fullURI += '/' + this.version;
     }
     return fullURI;
-  }
-
-  decode(dec, node, into) {
-    const meta = node;
-    if (meta != null) {
-      for (let i = 0; i < meta.attributes.length; i++) {
-        const attrib = meta.attributes[i];
-        if (attrib.specified == true && attrib.name != 'as') {
-          this[attrib.name] = attrib.value;
-        }
-      }
-      for (let i = 0; i < meta.children.length; i++) {
-        const childNode = meta.children[i];
-        if (childNode.getAttribute("as") === "otherTypes") {
-          this.otherTypes = dec.decode(childNode);
-        } else if (childNode.getAttribute("as") === "otherRoles") {
-          this.otherRoles = dec.decode(childNode);
-        } else if (childNode.getAttribute("as") === "annotations") {
-          this.annotations = dec.decode(childNode);
-        }
-      }
-    }
-    return this;
   }
 
   encode(enc: any) {
@@ -125,6 +108,16 @@ export class GlyphInfo {
       let annotationsNode = enc.encode(this.annotations);
       annotationsNode.setAttribute("as", "annotations");
       node.appendChild(annotationsNode);
+    }
+    if(this.derivedFroms){
+      let derivedFromsNode = enc.encode(this.derivedFroms);
+      derivedFromsNode.setAttribute("as", "derivedFroms");
+      node.appendChild(derivedFromsNode);
+    }
+    if(this.generatedBys){
+      let generatedBysNode = enc.encode(this.generatedBys);
+      generatedBysNode.setAttribute("as", "generatedBys");
+      node.appendChild(generatedBysNode);
     }
 
     return node;

--- a/SBOLCanvasFrontend/src/app/graph-base.ts
+++ b/SBOLCanvasFrontend/src/app/graph-base.ts
@@ -5,6 +5,7 @@ import { GlyphInfo } from './glyphInfo';
 import { InteractionInfo } from './interactionInfo';
 import { GlyphService } from './glyph.service';
 import { GraphHelpers } from './graph-helpers';
+import { CanvasAnnotation } from './canvasAnnotation';
 
 // mx is used here as the typings file for mxgraph isn't up to date.
 // Also if it weren't exported, other classes wouldn't get our extensions of the mxCell class.
@@ -158,24 +159,7 @@ export class GraphBase {
         const glyphInfoCodec = new mx.mxObjectCodec(new GlyphInfo());
         glyphInfoCodec.decode = function (dec, node, into) {
             const glyphData = new GlyphInfo();
-            const meta = node;
-            if (meta != null) {
-                for (let i = 0; i < meta.attributes.length; i++) {
-                    const attrib = meta.attributes[i];
-                    if (attrib.specified == true && attrib.name != 'as') {
-                        glyphData[attrib.name] = attrib.value;
-                    }
-                }
-                for (let i = 0; i < meta.children.length; i++) {
-                    const childNode = meta.children[i];
-                    if (childNode.getAttribute("as") === "otherTypes") {
-                        glyphData.otherTypes = dec.decode(childNode);
-                    } else if (childNode.getAttribute("as") === "otherRoles") {
-                        glyphData.otherRoles = dec.decode(childNode);
-                    }
-                }
-            }
-            return glyphData;
+            return glyphData.decode(dec, node, into);
         }
         glyphInfoCodec.encode = function (enc, object) {
             return object.encode(enc);
@@ -188,22 +172,25 @@ export class GraphBase {
         const interactionInfoCodec = new mx.mxObjectCodec(new InteractionInfo());
         interactionInfoCodec.decode = function (dec, node, into) {
             const interactionData = new InteractionInfo();
-            const meta = node;
-            if (meta != null) {
-                for (let i = 0; i < meta.attributes.length; i++) {
-                    const attrib = meta.attributes[i];
-                    if (attrib.specified == true && attrib.name != 'as') {
-                        interactionData[attrib.name] = attrib.value;
-                    }
-                }
-            }
-            return interactionData;
+            return interactionData.decode(dec, node, into);
         }
         interactionInfoCodec.encode = function (enc, object) {
             return object.encode(enc);
         }
         mx.mxCodecRegistry.register(interactionInfoCodec);
         window['InteractionInfo'] = InteractionInfo;
+
+        Object.defineProperty(CanvasAnnotation, "name", { configurable: true, value: "CanvasAnnotation" });
+        const canvasAnnotationCodec = new mx.mxObjectCodec(new CanvasAnnotation());
+        canvasAnnotationCodec.decode = function(dec, node, into){
+            const canvasAnnotation = new CanvasAnnotation();
+            return canvasAnnotation.decode(dec, node, into);
+        }
+        canvasAnnotationCodec.encode = function(enc, object){
+            return object.encode(enc);
+        }
+        mx.mxCodecRegistry.register(canvasAnnotationCodec);
+        window['CanvasAnnotation'] = CanvasAnnotation;
 
         // For circuitContainers, the order of the children matters.
         // We want it to match the order of the children's geometries

--- a/SBOLCanvasFrontend/src/app/graph-base.ts
+++ b/SBOLCanvasFrontend/src/app/graph-base.ts
@@ -153,13 +153,30 @@ export class GraphBase {
         window['mxPoint'] = mx.mxPoint;
         window['mxCell'] = mx.mxCell;
 
+        let genericDecode = function(dec, node, into){
+            const meta = node;
+            if (meta != null) {
+              for (let i = 0; i < meta.attributes.length; i++) {
+                const attrib = meta.attributes[i];
+                if (attrib.specified == true && attrib.name != 'as') {
+                  into[attrib.name] = attrib.value;
+                }
+              }
+              for (let i = 0; i < meta.children.length; i++) {
+                const childNode = meta.children[i];
+                into[childNode.getAttribute("as")] = dec.decode(childNode);
+              }
+            }
+            return into;
+        }
+
         //mxGraph uses function.name which uglifyJS breaks on production
         // Glyph info decode/encode
         Object.defineProperty(GlyphInfo, "name", { configurable: true, value: "GlyphInfo" });
         const glyphInfoCodec = new mx.mxObjectCodec(new GlyphInfo());
         glyphInfoCodec.decode = function (dec, node, into) {
             const glyphData = new GlyphInfo();
-            return glyphData.decode(dec, node, into);
+            return genericDecode(dec, node, glyphData);
         }
         glyphInfoCodec.encode = function (enc, object) {
             return object.encode(enc);
@@ -172,7 +189,7 @@ export class GraphBase {
         const interactionInfoCodec = new mx.mxObjectCodec(new InteractionInfo());
         interactionInfoCodec.decode = function (dec, node, into) {
             const interactionData = new InteractionInfo();
-            return interactionData.decode(dec, node, into);
+            return genericDecode(dec, node, interactionData);
         }
         interactionInfoCodec.encode = function (enc, object) {
             return object.encode(enc);
@@ -184,7 +201,7 @@ export class GraphBase {
         const canvasAnnotationCodec = new mx.mxObjectCodec(new CanvasAnnotation());
         canvasAnnotationCodec.decode = function(dec, node, into){
             const canvasAnnotation = new CanvasAnnotation();
-            return canvasAnnotation.decode(dec, node, into);
+            return genericDecode(dec, node, canvasAnnotation);
         }
         canvasAnnotationCodec.encode = function(enc, object){
             return object.encode(enc);

--- a/SBOLCanvasFrontend/src/app/graph-helpers.ts
+++ b/SBOLCanvasFrontend/src/app/graph-helpers.ts
@@ -846,7 +846,7 @@ export class GraphHelpers extends GraphBase {
     }
 
     protected removeViewCell(viewCell: mxCell) {
-        if (!viewCell || viewCell.isViewCell()) {
+        if (!viewCell || !viewCell.isViewCell()) {
             console.debug("Tried to remove a view cell that isn't a view cell!");
             return;
         }

--- a/SBOLCanvasFrontend/src/app/interactionInfo.ts
+++ b/SBOLCanvasFrontend/src/app/interactionInfo.ts
@@ -5,7 +5,7 @@ export class InteractionInfo {
   interactionType: string;
 
   constructor() {
-    this.displayID = 'Interaction'+(InteractionInfo.counter++);
+    this.displayID = 'Interaction' + (InteractionInfo.counter++);
     this.interactionType = "Yo momma";
   }
 
@@ -21,11 +21,24 @@ export class InteractionInfo {
     this.interactionType = other.interactionType;
   }
 
+  decode(dec, node, into) {
+    const meta = node;
+    if (meta != null) {
+      for (let i = 0; i < meta.attributes.length; i++) {
+        const attrib = meta.attributes[i];
+        if (attrib.specified == true && attrib.name != 'as') {
+          this[attrib.name] = attrib.value;
+        }
+      }
+    }
+    return this;
+  }
+
   encode(enc: any) {
     let node = enc.document.createElement('InteractionInfo');
-    if(this.displayID)
+    if (this.displayID)
       node.setAttribute("displayID", this.displayID);
-    if(this.interactionType)
+    if (this.interactionType)
       node.setAttribute("interactionType", this.interactionType);
     return node;
   }

--- a/SBOLCanvasFrontend/src/app/interactionInfo.ts
+++ b/SBOLCanvasFrontend/src/app/interactionInfo.ts
@@ -21,19 +21,6 @@ export class InteractionInfo {
     this.interactionType = other.interactionType;
   }
 
-  decode(dec, node, into) {
-    const meta = node;
-    if (meta != null) {
-      for (let i = 0; i < meta.attributes.length; i++) {
-        const attrib = meta.attributes[i];
-        if (attrib.specified == true && attrib.name != 'as') {
-          this[attrib.name] = attrib.value;
-        }
-      }
-    }
-    return this;
-  }
-
   encode(enc: any) {
     let node = enc.document.createElement('InteractionInfo');
     if (this.displayID)

--- a/SBOLCanvasFrontend/src/app/load-graph/load-graph.component.html
+++ b/SBOLCanvasFrontend/src/app/load-graph/load-graph.component.html
@@ -5,8 +5,13 @@
       <input hidden (change)="onFileSelected()" #fileInput type="file" id="file">
       <mat-label>{{filename}}</mat-label>
   </div>
+
+  <div *ngIf="working">
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  </div>
+
   <div mat-dialog-actions>
       <button mat-button (click)="onCancelClick()">Cancel</button>
-      <button mat-button [mat-dialog-close]="data.file">Ok</button>
+      <button mat-button [disabled]="!finishCheck()" (click)="onOkClick()">Ok</button>
   </div>
 </mat-card>

--- a/SBOLCanvasFrontend/src/app/load-graph/load-graph.component.ts
+++ b/SBOLCanvasFrontend/src/app/load-graph/load-graph.component.ts
@@ -1,6 +1,8 @@
 import {Component, Inject, OnInit} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material';
 import {LoadDialogData} from '../toolbar/toolbar.component';
+import { FilesService } from '../files.service';
+import { GraphService } from '../graph.service';
 
 @Component({
   selector: 'app-load-graph',
@@ -12,7 +14,9 @@ export class LoadGraphComponent implements OnInit {
   file:any;
   filename:any;
 
-  constructor(public dialogRef: MatDialogRef<LoadGraphComponent>, @Inject(MAT_DIALOG_DATA) public data: LoadDialogData) { }
+  working:boolean;
+
+  constructor(public dialogRef: MatDialogRef<LoadGraphComponent>, @Inject(MAT_DIALOG_DATA) public data: LoadDialogData, private filesService: FilesService, private graphService: GraphService) { }
 
   onFileSelected(){
     const fileInput: any = document.querySelector('#file');
@@ -21,10 +25,23 @@ export class LoadGraphComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.working = false;
+  }
+
+  onOkClick(){
+    this.working = true;
+    this.filesService.loadLocal(this.data.file, this.graphService).subscribe(_ => {
+      this.working = false;
+      this.dialogRef.close();
+    });
   }
 
   onCancelClick() {
     this.dialogRef.close();
+  }
+
+  finishCheck(){
+    return this.filename && this.filename.length > 0;
   }
 
 }

--- a/SBOLCanvasFrontend/src/app/save-graph/save-graph.component.html
+++ b/SBOLCanvasFrontend/src/app/save-graph/save-graph.component.html
@@ -6,8 +6,13 @@
       <input matInput [(ngModel)]="data.filename">
     </mat-form-field>
   </div>
+
+  <div *ngIf="working">
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  </div>
+
   <div mat-dialog-actions>
     <button mat-button (click)="onCancelClick()">Cancel</button>
-    <button mat-button [mat-dialog-close]="data.filename" cdkFocusInitial>Ok</button>
+    <button mat-button [disabled]="!finishCheck()" (click)="onOkClick()" cdkFocusInitial>Ok</button>
   </div>
 </mat-card>

--- a/SBOLCanvasFrontend/src/app/save-graph/save-graph.component.ts
+++ b/SBOLCanvasFrontend/src/app/save-graph/save-graph.component.ts
@@ -1,6 +1,8 @@
 import {Component, Inject, OnInit} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material';
 import { SaveDialogData } from '../toolbar/toolbar.component';
+import { FilesService } from '../files.service';
+import { GraphService } from '../graph.service';
 
 @Component({
   selector: 'app-save-graph',
@@ -9,13 +11,28 @@ import { SaveDialogData } from '../toolbar/toolbar.component';
 })
 export class SaveGraphComponent implements OnInit {
 
+  working: boolean;
+
   constructor(public dialogRef: MatDialogRef<SaveGraphComponent>,
-              @Inject(MAT_DIALOG_DATA) public data: SaveDialogData) { }
+              @Inject(MAT_DIALOG_DATA) public data: SaveDialogData, private filesService: FilesService, private graphService: GraphService) { }
 
   ngOnInit() {
+    this.working = false;
+  }
+
+  onOkClick(){
+    this.working = true;
+    this.filesService.saveLocal(this.data.filename, this.graphService.getGraphXML()).subscribe(_ => {
+      this.working = false;
+      this.dialogRef.close();
+    });
   }
 
   onCancelClick() {
     this.dialogRef.close();
+  }
+
+  finishCheck(){
+    return this.data.filename && this.data.filename.length > 0;
   }
 }

--- a/SBOLCanvasFrontend/src/app/toolbar/toolbar.component.ts
+++ b/SBOLCanvasFrontend/src/app/toolbar/toolbar.component.ts
@@ -43,10 +43,6 @@ export class ToolbarComponent implements OnInit, AfterViewInit {
     this.filesService.saveLocal(filename, this.graphService.getGraphXML());
   }
 
-  load(file: File) {
-    this.filesService.loadLocal(file, this.graphService);
-  }
-
   openUploadDialog(): void {
     this.dialog.open(UploadGraphComponent, {
       data: {componentMode: this.graphService.isRootAComponentView()}
@@ -80,9 +76,6 @@ export class ToolbarComponent implements OnInit, AfterViewInit {
     this.popupOpen = true;
     dialogRef.afterClosed().subscribe(result => {
       this.popupOpen = false;
-      if (result != null) {
-        this.load(result);
-      }
     });
   }
 


### PR DESCRIPTION
Doesn't create SBOL objects when their identity points to a synbiohub instance. Instead adds a registry to the document.

Also added busy visuals on local save/load due to longer conversion times.


Closes #99, #107