### PR TITLE
Fix ownership propagating to modules, and add a logout button

### DIFF
--- a/SBOLCanvasBackend/src/servlets/SynBioHub.java
+++ b/SBOLCanvasBackend/src/servlets/SynBioHub.java
@@ -94,8 +94,21 @@ public class SynBioHub extends HttpServlet {
 				user = sbhf.getUser();
 				body = user;
 
-			} else if (request.getPathInfo().equals("/listMyCollections")) {
-
+			} else if (request.getPathInfo().equals("/logout")) {
+			
+				if(server == null || user == null) {
+					response.setStatus(HttpStatus.SC_BAD_REQUEST);
+					return;
+				}
+				
+				SynBioHubFrontend sbhf = new SynBioHubFrontend(server);
+				sbhf.setUser(user);
+				sbhf.logout();
+				response.setStatus(HttpStatus.SC_OK);
+				return;
+				
+			}else if (request.getPathInfo().equals("/listMyCollections")) {
+				
 				if (server == null || user == null) {
 					response.setStatus(HttpStatus.SC_BAD_REQUEST);
 					return;

--- a/SBOLCanvasFrontend/src/app/download-graph/download-graph.component.html
+++ b/SBOLCanvasFrontend/src/app/download-graph/download-graph.component.html
@@ -100,7 +100,8 @@
   </div>
 
   <div mat-dialog-actions>
-    <button mat-button [disabled]="loginDisabled()" (click)="onLoginClick()">Login</button>
+    <button mat-button *ngIf="!loginDisabled()" [disabled]="!registry" (click)="onLoginClick()">Login</button>
+    <button mat-button *ngIf="loginDisabled()" [disabled]="!registry" (click)="onLogoutClick()">Logout</button>
     <button mat-button (click)="onCancelClick()">Cancel</button>
     <button mat-button [disabled]="!enterCollectionEnabled()" (click)="onEnterCollectionClick()">Enter Collection</button>
     <button *ngIf="mode != classRef.SELECT_MODE" mat-button [disabled]="!finishCheck()" (click)="onDownloadClick()">Download</button>

--- a/SBOLCanvasFrontend/src/app/download-graph/download-graph.component.ts
+++ b/SBOLCanvasFrontend/src/app/download-graph/download-graph.component.ts
@@ -157,6 +157,13 @@ export class DownloadGraphComponent implements OnInit {
     });
   }
 
+  async onLogoutClick() {
+    this.working = true;
+    await this.loginService.logout(this.registry);
+    this.working = false;
+    this.updateParts();
+  }
+
   onCancelClick() {
     this.dialogRef.close();
   }

--- a/SBOLCanvasFrontend/src/app/graph-helpers.ts
+++ b/SBOLCanvasFrontend/src/app/graph-helpers.ts
@@ -1631,6 +1631,11 @@ export class GraphHelpers extends GraphBase {
                                     // edge case, module view, need to check parent circuit container
                                     toCheck.add(cell.getParent().getValue());
                                 }
+                            } else if(cell.isCircuitContainer() && cell.getParent().isModuleView()){
+                                // transition state to module views
+                                toCheck.add(cell.getParent().getId());
+                            } else if(cell.isModule()){
+                                toCheck.add(cell.getParent().getId());
                             }
                         }
                     }

--- a/SBOLCanvasFrontend/src/app/login.service.ts
+++ b/SBOLCanvasFrontend/src/app/login.service.ts
@@ -15,6 +15,7 @@ export interface LoginDialogData {
 export class LoginService {
   
   private loginURL = environment.backendURL + '/SynBioHub/login';
+  private logoutURL = environment.backendURL + '/SynBioHub/logout';
 
   public users: {} = {};
 
@@ -37,6 +38,16 @@ export class LoginService {
     let params = new HttpParams();
     params = params.append("server", server);
     return this.http.get(this.loginURL, { responseType: 'text', headers: headers, params: params });
+  }
+
+  async logout(server: string) {
+    let headers = new HttpHeaders();
+    headers = headers.set("Authorization", this.users[server]);
+    let params = new HttpParams();
+    params = params.append("server", server);
+    await this.http.get(this.logoutURL, { headers: headers, params: params }).toPromise();
+
+    delete this.users[server];
   }
 
 }


### PR DESCRIPTION
Fixes taking ownership of a component definition not propagating ownership to modules.
Adds a logout button to the various download modals where previously the login button was just disabled.