### PR TITLE
Visualizing sequence feature glyphs without backbone

### DIFF
--- a/SBOLCanvasFrontend/src/app/glyph-menu/glyph-menu.component.ts
+++ b/SBOLCanvasFrontend/src/app/glyph-menu/glyph-menu.component.ts
@@ -44,7 +44,8 @@ export class GlyphMenuComponent implements OnInit, AfterViewInit {
   }
 
   onSequenceFeatureGlyphClicked(name: string) {
-    this.graphService.addSequenceFeature(name);
+    //this.graphService.addSequenceFeature(name);
+    this.graphService.addSequenceFeatureWithoutBackbone(name);
   }
 
   onMolecularSpeciesGlyphClicked(name: string) {

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -753,7 +753,33 @@ export class GraphService extends GraphHelpers {
             this.graph.getModel().endUpdate();
         }
     }
+  /**
+     * Creates sequence feature without backbone
+     */
+  addSequenceFeatureWithoutBackbone(name){
+    const pt = this.getDefaultNewCellCoords();
+    this.addSequenceFeatureWithoutBackboneAt(name, pt.x, pt.y);
+}
 
+addSequenceFeatureWithoutBackboneAt(name, x,y){
+    this.graph.getModel().beginUpdate();
+    try{
+        const glyphInfo = new GlyphInfo({
+            partRole: name
+        });
+        this.addToInfoDict(glyphInfo);
+
+        const sequenceFeatureCell = this.graph.insertVertex(this.graph.getDefaultParent(), null, glyphInfo.getFullURI(), x, y, GraphBase.sequenceFeatureGlyphWidth, GraphBase.sequenceFeatureGlyphHeight, GraphBase.STYLE_SEQUENCE_FEATURE + name);
+
+        this.createViewCell(glyphInfo.getFullURI());
+        sequenceFeatureCell.setConnectable(true);
+        
+        this.graph.clearSelection();
+        this.graph.setSelectionCell(sequenceFeatureCell)
+    } finally {
+        this.graph.getModel().endUpdate();
+    }
+}
     /**
      * Turns the given element into a dragsource for creating molecular species glyphs
      */


### PR DESCRIPTION
When a new glyph is added, it is generated without backbone (the same way as molecular species).

I'm not sure if an option should be added ..
 1) original way of adding backbone
 2)  Adding without backbone


 
 