### PR TITLE
Copy Paste Feature

### DIFF
--- a/SBOLCanvasFrontend/src/app/color-picker/color-picker.component.ts
+++ b/SBOLCanvasFrontend/src/app/color-picker/color-picker.component.ts
@@ -1,6 +1,7 @@
 import {Component, Inject, OnInit} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {ColorPickerStartupData} from '../design-menu/design-menu.component';
+import { take } from 'rxjs';
 
 @Component({
   selector: 'app-color-picker',
@@ -71,7 +72,7 @@ export class ColorPickerComponent implements OnInit {
 
 
   ngOnInit() {
-    this.dialogRef.beforeClosed().subscribe(() => this.dialogRef.close(this.selectedColor));
+    this.dialogRef.beforeClosed().pipe(take(1)).subscribe(() => this.dialogRef.close(this.selectedColor));
     this.selectedColor = this.data.initialColor;
   }
 

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -25,6 +25,7 @@ import { EmbeddedService } from './embedded.service';
 import { FilesService } from './files.service';
 import { Observable } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
+import { mxClipboard } from 'src/mxgraph';
 
 @Injectable({
     providedIn: 'root'
@@ -571,6 +572,35 @@ export class GraphService extends GraphHelpers {
         this.filterSelectionCells();
     }
 
+    copy(){
+        mx.mxClipboard.copy(this.graph)
+        console.log(mx.mxClipboard.getCells())
+        console.log(mx.mxClipboard.getCells()[0].isInteraction())
+        // this.addSequenceFeature(cell.style.split("Glyph")[1].trim()) 
+    }
+
+    paste(){
+        let cells = mx.mxClipboard.getCells()
+        this.graph.clearSelection()
+        // this.addBackbone()
+        for(let cell of cells){
+            if (cell.isCircuitContainer()){
+                for(let children of cell.children){
+                    if(!children.isBackbone()){
+                        this.addSequenceFeature(children.style.split("Glyph")[1].trim()) 
+                    }
+                    
+                    
+                }
+            }
+            else{  
+                console.log("add")
+                this.addSequenceFeature(cell.style.split("Glyph")[1].trim()) 
+            }
+
+        }
+    }
+
     zoomIn() {
         this.graph.zoomIn();
     }
@@ -626,9 +656,10 @@ export class GraphService extends GraphHelpers {
      * The new glyph's location is based off the user's selection.
      */
     addSequenceFeature(name) {
+        console.log(name)
         this.graph.getModel().beginUpdate();
         try {
-            if (!this.atLeastOneCircuitContainerInGraph()) {
+            if (!this.atLeastOneCircuitContainerInGraph() || this.graph.getSelectionCells().length === 0 ) {
                 // if there is no strand, quietly make one
                 // stupid user
                 this.addBackbone();
@@ -674,7 +705,6 @@ export class GraphService extends GraphHelpers {
      * glyph is added (first, second, etc)
      */
     async addSequenceFeatureAt(name, x, y, circuitContainer?) {
-
         // ownership change check
         if (this.graph.getCurrentRoot()) {
             let glyphInfo;

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -576,7 +576,6 @@ export class GraphService extends GraphHelpers {
     */
     copy(){
         mx.mxClipboard.copy(this.graph, this.graph.getSelectionCells())
-        console.log(this.graph.getSelectionCell())
     }
     
     // Map old cells to newly created cells in the paste method 

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -604,7 +604,7 @@ export class GraphService extends GraphHelpers {
         const circuitContainers = []
         
         for(let cell of cells){
-            const cellName = cell.style.split("Glyph")[1]?.trim()
+            const cellName = cell.style.split("Glyph")[1]?.split(";")[0]?.trim()
             
             // circuit container refers to the blue box, the children being the cells in that box
             if (cell.isCircuitContainer()){
@@ -612,7 +612,7 @@ export class GraphService extends GraphHelpers {
                 for(let childCell of cell.children){
                     if(!childCell.isBackbone()){
                         
-                        const childCellName = childCell.style.split("Glyph")[1].trim()
+                        const childCellName = childCell.style.split("Glyph")[1]?.split(";")[0]?.trim()
                         const edges = childCell?.edges // an array of interaction glyphs connected to the current child, may be undefined
     
                         this.addSequenceFeature(childCellName)
@@ -622,6 +622,8 @@ export class GraphService extends GraphHelpers {
 
                             for(let edge of edges){
                                 const edgeName = edge.style.split("Glyph")[1].trim()
+                                
+                                if(edge.target === childCell) continue
                                 
                                 this.addInteraction(edgeName)
                                 interactions.push(selectedCell()) 

--- a/SBOLCanvasFrontend/src/app/home/home.component.ts
+++ b/SBOLCanvasFrontend/src/app/home/home.component.ts
@@ -12,6 +12,8 @@ export enum KEY_CODE {
   BACKSPACE = "Backspace",
   UNDO = "Undo",
   REDO = "Redo",
+  COPY = "Copy",
+  PASTE = "Paste"
 }
 
 @Component({
@@ -51,6 +53,17 @@ export class HomeComponent implements OnInit, ComponentCanDeactivate {
     this.handleEvent(event, KEY_CODE.REDO);
   }
 
+  @HostListener('window:keydown.control.c', ['$event'])
+  onControlCHandler(event: KeyboardEvent) {
+    console.debug('Copy');
+    this.handleEvent(event, KEY_CODE.COPY);
+  }
+  @HostListener('window:keydown.control.v', ['$event'])
+  onControlVHandler(event: KeyboardEvent) {
+    console.debug('Paste');
+    this.handleEvent(event, KEY_CODE.PASTE);
+  }
+
   handleEvent(event: KeyboardEvent, code: string) {
 
     const target = event.target as HTMLElement;
@@ -60,6 +73,7 @@ export class HomeComponent implements OnInit, ComponentCanDeactivate {
     if ((target == null || (target.tagName != "INPUT" && target.tagName != "TEXTAREA" && target.tagName != "DIV")) && !this.toolbar.popupOpen) {
       // prevent default actions on keypresses using preventDefault()
 
+
       if (code === KEY_CODE.DELETE || code === KEY_CODE.BACKSPACE) {
         this.graphService.delete();
       }
@@ -68,6 +82,12 @@ export class HomeComponent implements OnInit, ComponentCanDeactivate {
       }
       else if (code == KEY_CODE.REDO) {
         this.graphService.redo();
+      }
+      else if (code == KEY_CODE.COPY) {
+        this.graphService.copy();
+      }
+      else if (code == KEY_CODE.PASTE) {
+        this.graphService.paste();
       }
     }
   }

--- a/SBOLCanvasFrontend/src/app/info-editor/info-editor.component.ts
+++ b/SBOLCanvasFrontend/src/app/info-editor/info-editor.component.ts
@@ -225,7 +225,7 @@ export class InfoEditorComponent implements OnInit {
   glyphInfoUpdated(glyphInfo: GlyphInfo) {
     this.glyphInfo = glyphInfo;
     
-    this.glyphCtrl = new FormControl( `${this.glyphInfo.displayID}`, Validators.required);
+    this.glyphCtrl = new FormControl( `${this.glyphInfo?.displayID}`, Validators.required);
     if (glyphInfo != null) {
       if (glyphInfo.partRole != null) {
         this.getRefinements(glyphInfo.partRole);


### PR DESCRIPTION
When pasting, it is essentially creating a new instance of each copied glyph. 

It is possible to keep certain attributes of the copied glyph like its color or if it was an imported component.
Felt like having a new instance was better but I'm not too sure.

Any thoughts?

