### PR TITLE
Fix Nullpointers for SynBioSuite

### DIFF
--- a/SBOLCanvasFrontend/src/app/graph-base.ts
+++ b/SBOLCanvasFrontend/src/app/graph-base.ts
@@ -1249,6 +1249,11 @@ export class GraphBase {
         if (source && target && source.isInteractionNode() && target.isInteractionNode()) {
             return 'Interaction nodes aren\'t allowed to connect.';
         }
+        
+        // Prevent connecting of an edge to circuit container by clicking it and then an interaction 
+        if(source.isCircuitContainer()){
+            return 'Edge type disallowed to connect to a circuit container. Please connect to the glyph itself.';
+        }
 
         return null;
     }

--- a/SBOLCanvasFrontend/src/app/graph-helpers.ts
+++ b/SBOLCanvasFrontend/src/app/graph-helpers.ts
@@ -50,6 +50,7 @@ export class GraphHelpers extends GraphBase {
         const rootModuleInfo = new ModuleInfo();
         this.addToInfoDict(rootModuleInfo);
         const rootViewCell = this.graph.insertVertex(cell1, rootModuleInfo.getFullURI(), "", 0, 0, 0, 0, GraphBase.STYLE_MODULE_VIEW);
+        rootViewCell.setConnectable(false)
         this.graph.enterGroup(rootViewCell);
         this.viewStack = [];
         this.viewStack.push(rootViewCell);

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -576,7 +576,6 @@ export class GraphService extends GraphHelpers {
     */
     copy(){
         mx.mxClipboard.copy(this.graph, this.graph.getSelectionCells())
-        console.log(this.graph.getSelectionCell())
     }
     
     // Map old cells to newly created cells in the paste method 
@@ -1387,14 +1386,9 @@ export class GraphService extends GraphHelpers {
                     element.refreshCircuitContainer(this.graph);
                     
                     // Doesn't remember cell specific properties like if they were connectable
-                    // Might be a way to set this in the xml? This if fine for one property though
+                    // since it's being converted from SBOL to mxGraph XML
                     element.setConnectable(false)
-                    for(let child of element.children){
-                        if(child.isBackbone()){
-                            child.setConnectable(false)
-                            break;
-                        }
-                    }
+                    element.getBackbone().setConnectable(false)
                 }
             });
         }

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -576,6 +576,7 @@ export class GraphService extends GraphHelpers {
     */
     copy(){
         mx.mxClipboard.copy(this.graph, this.graph.getSelectionCells())
+        console.log(this.graph.getSelectionCell())
     }
     
     // Map old cells to newly created cells in the paste method 
@@ -1770,6 +1771,7 @@ export class GraphService extends GraphHelpers {
             let rootModuleInfo = new ModuleInfo();
             this.addToInfoDict(rootModuleInfo);
             rootViewCell = this.graph.insertVertex(cell1, rootModuleInfo.getFullURI(), "", 0, 0, 0, 0, GraphBase.STYLE_MODULE_VIEW);
+            rootViewCell.setConnectable(false)
             this.graph.enterGroup(rootViewCell);
             this.viewStack.push(rootViewCell);
         } else { // User picked New Component Design

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -1370,6 +1370,7 @@ export class GraphService extends GraphHelpers {
         for (let child of viewCells) {
             if (!child.isViewCell()) {
                 rootViewCell = this.graph.getModel().getCell(child.getValue());
+                rootViewCell.setConnectable(false)
                 this.graph.getModel().remove(child);
                 break;
             }
@@ -1382,8 +1383,19 @@ export class GraphService extends GraphHelpers {
         let children = this.graph.getModel().getChildren(this.graph.getDefaultParent());
         if (children) {
             children.forEach(element => {
-                if (element.isCircuitContainer())
+                if (element.isCircuitContainer()){
                     element.refreshCircuitContainer(this.graph);
+                    
+                    // Doesn't remember cell specific properties like if they were connectable
+                    // Might be a way to set this in the xml? This if fine for one property though
+                    element.setConnectable(false)
+                    for(let child of element.children){
+                        if(child.isBackbone()){
+                            child.setConnectable(false)
+                            break;
+                        }
+                    }
+                }
             });
         }
 


### PR DESCRIPTION
Fixed interaction snapping issue as seen here: MyersResearchGroup/SynBioSuite#32.

Made sure the backbone and circuit container stayed unconnectable within the embedded SBOLCanvas in SynBioSuite. 

I believe these were the major causes that led to the null pointer errors described in: MyersResearchGroup/SynBioSuite#26.