### PR TITLE
Exported images of plasmids fix

### DIFF
--- a/SBOLCanvasFrontend/src/app/graph-helpers.ts
+++ b/SBOLCanvasFrontend/src/app/graph-helpers.ts
@@ -1892,6 +1892,22 @@ export class GraphHelpers extends GraphBase {
     }
 
     /**
+     * Returns true if there is a Chromosomal Locus or Circular Backbone
+     * in the current graph view 
+     */
+    protected atLeastOneCircularOrChromosomalInGraph() {
+        let allGraphCells = this.graph.getDefaultParent().children
+        if (allGraphCells != null) {
+            for (let i = 0; i < allGraphCells.length; i++) {
+                if (allGraphCells[i].hasCircularBackbone() || allGraphCells[i].hasChromosomalLocus()) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    /**
      * Made specifically for undo, since it does not affect glyph info.
      * Removes "Circular" from the "otherTypes" property of Circuit Containers.
      */

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -1521,6 +1521,12 @@ export class GraphService extends GraphHelpers {
         var bounds = this.graph.getGraphBounds()
         var vs = this.graph.view.scale
 
+        // To prevent the plasmid edges from being cut off in exported images
+        if(this.atLeastOneCircularOrChromosomalInGraph()){
+            bounds.x -= 50
+            bounds.width += 100
+        }
+
         // Prepares SVG document that holds the output
         var svgDoc = mx.mxUtils.createXmlDocument()
         var root = (svgDoc.createElementNS != null) ?
@@ -1574,6 +1580,12 @@ export class GraphService extends GraphHelpers {
         let imgExport = new mx.mxImageExport()
         let bounds = this.graph.getGraphBounds()
         let vs = this.graph.view.scale
+
+        // To prevent the plasmid edges from being cut off in exported images
+        if(this.atLeastOneCircularOrChromosomalInGraph()){
+            bounds.x -= 50
+            bounds.width += 100
+        }
 
         let xmlDoc = mx.mxUtils.createXmlDocument()
         let root = xmlDoc.createElement('output')


### PR DESCRIPTION
Closes #354 

Modified the rendering bounds of images if a circular backbone or chromosomal locus is present in the design so their edges don't get cut off.