### PR TITLE
Centering when focusing in or out of a part

### DIFF
--- a/SBOLCanvasFrontend/src/app/graph-edits.ts
+++ b/SBOLCanvasFrontend/src/app/graph-edits.ts
@@ -193,9 +193,8 @@ export class GraphEdits {
                 } else {
                     this.glyphCell = previousView;
                 }
-                
-                this.graphService.fitCamera();
             }
+            this.graphService.fitCamera();
         }
     }
 


### PR DESCRIPTION
When focusing in or out of a part, it will always be centered. Should prevent users from being lost on where their design went. 

Closes #352 