### PR TITLE
Github Release version takes priority over package.json version

### DIFF
--- a/SBOLCanvasFrontend/git.version.js
+++ b/SBOLCanvasFrontend/git.version.js
@@ -1,6 +1,7 @@
 const { writeFileSync } = require('fs');
 const { promisify } = require('util');
 const child = require('child_process');
+const { version } = require('os');
 const exec = promisify(child.exec);
 
 async function createVersionsFile(filename) {
@@ -8,8 +9,16 @@ async function createVersionsFile(filename) {
     ?? (await exec('git rev-parse --short HEAD')).stdout.toString().trim();
   const branch = process.argv[3]
     ?? (await exec('git rev-parse --abbrev-ref HEAD')).stdout.toString().trim();
-  let version = (await exec('git tag --points-at HEAD')).stdout.toString().trim()
-    ?? process.env.npm_package_version;
+  
+  let version = ''
+  try{
+    const {stdout} = (await exec('git describe --tags --abbrev=0')) 
+    version = stdout.trim()
+  }
+  catch{
+    version = process.env.npm_package_version
+  }
+
   if (version == '') {
     version = 'Latest';
   }

--- a/SBOLCanvasFrontend/git.version.js
+++ b/SBOLCanvasFrontend/git.version.js
@@ -8,9 +8,8 @@ async function createVersionsFile(filename) {
     ?? (await exec('git rev-parse --short HEAD')).stdout.toString().trim();
   const branch = process.argv[3]
     ?? (await exec('git rev-parse --abbrev-ref HEAD')).stdout.toString().trim();
-  let version = process.env.npm_package_version
-    ?? (await exec('git tag --points-at HEAD')).stdout.toString().trim();
-
+  let version = (await exec('git tag --points-at HEAD')).stdout.toString().trim()
+    ?? process.env.npm_package_version;
   if (version == '') {
     version = 'Latest';
   }

--- a/SBOLCanvasFrontend/package.json
+++ b/SBOLCanvasFrontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbolcanvas-frontend",
-  "version": "0.0.0",
+  "version": "1.4.0",
   "scripts": {
     "bundle-report": "ng build --configuration production --stats-json && webpack-bundle-analyzer dist/SBOLCanvasFrontend/stats.json",
     "prebuild": "npm rebuild sass && node assetBundler.js",


### PR DESCRIPTION
Turns out the package.json version was taking priority instead of the github release version so I swapped the priorities. I've also updated the package.json to be the current 1.4 version as well.

Closes #363 