### PR TITLE
Fix circular import

### DIFF
--- a/SBOLCanvasBackend/.project
+++ b/SBOLCanvasBackend/.project
@@ -6,11 +6,6 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.wst.common.project.facet.core.builder</name>
 			<arguments>
 			</arguments>
@@ -25,7 +20,6 @@
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
 		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
-		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 	</natures>
 	<filteredResources>

--- a/SBOLCanvasBackend/src/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/utils/SBOLToMx.java
@@ -268,10 +268,12 @@ public class SBOLToMx extends Converter {
 			Component[] glyphArray = compDef.getSortedComponents().toArray(new Component[0]);
 			List<Component> newList = new ArrayList<>(Arrays.asList(glyphArray));
 			Component duplicateToAdd = null;
+
+			// Check if a circular backbone is present, if so add a duplicate for the right end in SBOLCanvas
 			for(Component glyph: newList){
-				if(glyph.getDisplayId().toString().contains("Cir")){
+				ComponentDefinition cd = (glyph.getDefinition());
+				if (cd != null && cd.getRoles().iterator().next().equals(SBOLData.roles.getValue("Cir (Circular Backbone)"))) {
 					duplicateToAdd = glyph;
-	
 				}
 			}
 			if(duplicateToAdd != null){
@@ -395,10 +397,12 @@ public class SBOLToMx extends Converter {
 		Component[] glyphArray = compDef.getSortedComponents().toArray(new Component[0]);
 		List<Component> newList = new ArrayList<>(Arrays.asList(glyphArray));
 		Component duplicateToAdd = null;
-		for(Component glyph: newList){
-			if(glyph.getDisplayId().toString().contains("Cir")){
-				duplicateToAdd = glyph;
 
+		// Check if a circular backbone is present, if so add a duplicate for the right end in SBOLCanvas
+		for(Component glyph: newList){
+			ComponentDefinition cd = glyph.getDefinition();
+			if (cd != null && cd.getRoles().iterator().next().equals(SBOLData.roles.getValue("Cir (Circular Backbone)"))) {
+				duplicateToAdd = glyph;
 			}
 		}
 		if(duplicateToAdd != null){

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -1711,7 +1711,7 @@ export class GraphService extends GraphHelpers {
                 || selectionCells[0].isModule())) ||
                 (selectionCells.length == 2 && selectionCells[0].isCircularBackbone())) {
             // We're making a new cell to replace the selected one
-            let selectedCircularCells: mxCell[] = [] // Used only if importing Ciruclar Backbones
+            let selectedCircularCells: mxCell[] = undefined // Used only if importing Ciruclar Backbones
             let selectedCell
             if (selectionCells.length > 0) {
                 selectedCell = selectionCells[0]
@@ -1781,8 +1781,10 @@ export class GraphService extends GraphHelpers {
                     // generated cells don't have a proper geometry
                     newCell.setStyle(selectedCell.getStyle())
                     this.graph.getModel().setGeometry(newCell, selectedCell.geometry)
-                    console.log(newCell)
-                    newCell.stayAtBeginning = true
+                    if(selectedCell.isCircularBackbone()){
+                        newCell.stayAtBeginning = true
+                        selectedCircularCells[0].value = newCell.value // right side of the backbone should have same value as left side
+                    }
 
                     // add new cell to the graph
                     this.graph.getModel().add(origParent, newCell, origParent.getIndex(selectedCell))
@@ -1855,10 +1857,7 @@ export class GraphService extends GraphHelpers {
                         this.removeFromInfoDict(viewCells[i].getId())
                     }
                     this.addToInfoDict(subGlyphDict[GraphBase.INFO_DICT_INDEX][viewCells[i].getId()])
-                    // Sync up the right side of a circular backbone to have the same info
-                    if(selectedCircularCells){
-                        this.getGlyphInfo(selectedCircularCells[0]).name = subGlyphDict[GraphBase.INFO_DICT_INDEX][viewCells[i].getId()].displayID
-                    }
+
                     // add any molecular species or interactions to the info dict
                     for (let child of viewClone.children) {
                         if (child.isMolecularSpeciesGlyph()) {

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -1703,17 +1703,27 @@ export class GraphService extends GraphHelpers {
      */
     async setSelectedToXML(cellString: string) {
         const selectionCells = this.graph.getSelectionCells()
-
-        if (selectionCells.length == 0 || (selectionCells.length == 1 && (selectionCells[0].isSequenceFeatureGlyph() || selectionCells[0].isMolecularSpeciesGlyph() || selectionCells[0].isCircuitContainer() || selectionCells[0].isModule()))) {
+        if (selectionCells.length == 0 || 
+            (selectionCells.length == 1 && 
+                (selectionCells[0].isSequenceFeatureGlyph() 
+                || selectionCells[0].isMolecularSpeciesGlyph() 
+                || selectionCells[0].isCircuitContainer() 
+                || selectionCells[0].isModule())) ||
+                (selectionCells.length == 2 && selectionCells[0].isCircularBackbone())) {
             // We're making a new cell to replace the selected one
+            let selectedCircularCells: mxCell[] = [] // Used only if importing Ciruclar Backbones
             let selectedCell
             if (selectionCells.length > 0) {
                 selectedCell = selectionCells[0]
+            
+            if (selectionCells.length == 2 && selectionCells[1].isCircularBackbone() && selectionCells[0].isCircularBackbone()){
+                selectedCircularCells = selectionCells
+                selectedCell = selectionCells[1] // The left part of the backbone
+            }
             } else {
                 // nothing selected means we're replacing the view cell
                 selectedCell = this.graph.getCurrentRoot()
             }
-
             this.graph.getModel().beginUpdate()
             try {
                 let inModuleView = this.graph.getCurrentRoot().isModuleView()
@@ -1764,13 +1774,15 @@ export class GraphService extends GraphHelpers {
                 // not part of a module or a top level component definition
                 // Molecular species should not be able to be transformed into other part roles
                 let origParent;
-                if (selectedCell.isSequenceFeatureGlyph() || (selectedCell.isMolecularSpeciesGlyph() && newCell.isMolecularSpeciesGlyph())) {
+                if (selectedCell.isSequenceFeatureGlyph() || (selectedCell.isMolecularSpeciesGlyph() && newCell.isMolecularSpeciesGlyph() || selectedCell.isCircularBackbone())) {
                     // store old cell's parent
                     origParent = selectedCell.getParent()
 
                     // generated cells don't have a proper geometry
                     newCell.setStyle(selectedCell.getStyle())
                     this.graph.getModel().setGeometry(newCell, selectedCell.geometry)
+                    console.log(newCell)
+                    newCell.stayAtBeginning = true
 
                     // add new cell to the graph
                     this.graph.getModel().add(origParent, newCell, origParent.getIndex(selectedCell))
@@ -1843,7 +1855,10 @@ export class GraphService extends GraphHelpers {
                         this.removeFromInfoDict(viewCells[i].getId())
                     }
                     this.addToInfoDict(subGlyphDict[GraphBase.INFO_DICT_INDEX][viewCells[i].getId()])
-
+                    // Sync up the right side of a circular backbone to have the same info
+                    if(selectedCircularCells){
+                        this.getGlyphInfo(selectedCircularCells[0]).name = subGlyphDict[GraphBase.INFO_DICT_INDEX][viewCells[i].getId()].displayID
+                    }
                     // add any molecular species or interactions to the info dict
                     for (let child of viewClone.children) {
                         if (child.isMolecularSpeciesGlyph()) {


### PR DESCRIPTION
When importing a circular backbone from SynBioHub glyph info is updated correctly and is visually correct.