### PR TITLE
Fix: SBML export and Model tab frontend-backend connection

### DIFF
--- a/SBOLCanvasBackend/src/servlets/Convert.java
+++ b/SBOLCanvasBackend/src/servlets/Convert.java
@@ -79,7 +79,8 @@ public class Convert extends HttpServlet {
 		} catch (SBOLValidationException | IOException | SBOLConversionException | ParserConfigurationException
 				| TransformerException | SAXException | TransformerFactoryConfigurationError | URISyntaxException | SynBioHubException | javax.xml.stream.XMLStreamException e) {
 			ServletOutputStream outputStream = response.getOutputStream();
-			InputStream inputStream = new ByteArrayInputStream(e.getMessage().getBytes());
+			String message = e.getMessage() != null ? e.getMessage() : "Export failed";
+			InputStream inputStream = new ByteArrayInputStream(message.getBytes());
 			IOUtils.copy(inputStream, outputStream);
 
 			response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/SBOLCanvasBackend/src/servlets/Convert.java
+++ b/SBOLCanvasBackend/src/servlets/Convert.java
@@ -32,6 +32,11 @@ public class Convert extends HttpServlet {
 
 	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
 		try {
+			if (request.getPathInfo() == null) {
+				response.setStatus(HttpStatus.SC_BAD_REQUEST);
+				return;
+			}
+
 			if (request.getPathInfo().equals("/toMxGraph")) {
 				SBOLToMx converter = new SBOLToMx();
 				converter.toGraph(request.getInputStream(), response.getOutputStream());

--- a/SBOLCanvasBackend/src/servlets/Data.java
+++ b/SBOLCanvasBackend/src/servlets/Data.java
@@ -23,6 +23,11 @@ public class Data extends HttpServlet {
 
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 		try {
+			if (request.getPathInfo() == null) {
+				response.setStatus(HttpStatus.SC_BAD_REQUEST);
+				return;
+			}
+
 			// setup the json
 			Gson gson = new Gson();
 			String body = null;

--- a/SBOLCanvasBackend/src/servlets/Data.java
+++ b/SBOLCanvasBackend/src/servlets/Data.java
@@ -52,6 +52,11 @@ public class Data extends HttpServlet {
 				body = gson.toJson(SBOLData.getSimulationConfig());
 			}
 
+			if (body == null) {
+				response.setStatus(HttpStatus.SC_BAD_REQUEST);
+				return;
+			}
+
 			// write it to the response body
 			ServletOutputStream outputStream = response.getOutputStream();
 			InputStream inputStream = new ByteArrayInputStream(body.getBytes());

--- a/SBOLCanvasBackend/src/utils/MxToSBML.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBML.java
@@ -753,7 +753,7 @@ public class MxToSBML extends Converter {
 			if (eventId == null || eventId.isEmpty()) {
 				eventId = eventInfo.getDisplayID();
 			}
-			Event event = sbmlModel.createEvent(eventId);
+			Event event = sbmlModel.createEvent(sanitizeId(eventId));
 			event.setUseValuesFromTriggerTime(false);
 
 			// Trigger hardcoded to true. TODO: add conditional triggers

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.css
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.css
@@ -20,3 +20,8 @@
 .model-section > * {
   width: 100%;
 }
+
+.config-error {
+  color: #f44336;
+  padding: 8px;
+}

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
@@ -1,7 +1,6 @@
 <div *ngIf="configLoadError" class="config-error">
-  Failed to load simulation<br>
-  defaults from backend.<br>
-  Check that the server is running.
+  Failed to load simulation fields<br>
+  from backend.<br>
 </div>
 <div *ngIf="simulationConfig">
   <!-- Glyph Simulation Parameters -->

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
@@ -1,3 +1,8 @@
+<div *ngIf="configLoadError" class="config-error">
+  Failed to load simulation<br>
+  defaults from backend.<br>
+  Check that the server is running.
+</div>
 <div *ngIf="simulationConfig">
   <!-- Glyph Simulation Parameters -->
   <div *ngIf="glyphInfo" class="model-menu-container">

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="configLoadError" class="config-error">
+<div *ngIf="configLoadError && !simulationConfig" class="config-error">
   Failed to load simulation fields<br>
   from backend.<br>
 </div>

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.ts
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.ts
@@ -102,7 +102,7 @@ export class ModelEditorComponent implements OnInit {
 
   getSimulationConfig() {
     this.metadataService.loadSimulationConfig().subscribe({
-      next: config => { this.simulationConfig = config; },
+      next: config => { this.simulationConfig = config; this.configLoadError = false; },
       error: () => {
         console.warn('Failed to load simulation config from backend');
         this.simulationConfig = null;

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.ts
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.ts
@@ -76,7 +76,8 @@ export class ModelEditorComponent implements OnInit {
   glyphInfo: GlyphInfo;
   interactionInfo: InteractionInfo;
   eventInfo: EventInfo;
-  simulationConfig: SimulationConfig = {};
+  simulationConfig: SimulationConfig = null;
+  configLoadError = false;
 
   validationErrors: { [fieldId: string]: string } = {};
 
@@ -100,23 +101,22 @@ export class ModelEditorComponent implements OnInit {
   }
 
   getSimulationConfig() {
-    this.metadataService.loadSimulationConfig().subscribe(config => {
-      this.simulationConfig = config;
+    this.metadataService.loadSimulationConfig().subscribe({
+      next: config => { this.simulationConfig = config; },
+      error: () => {
+        console.warn('Failed to load simulation config from backend');
+        this.simulationConfig = null;
+        this.configLoadError = true;
+      }
     });
   }
 
   getDefaultValue(roleOrType: string, paramName: string): number {
-    if (!this.simulationConfig) {
-      throw new Error('Simulation config not loaded');
-    }
-    if (!this.simulationConfig[roleOrType]) {
-      throw new Error(`No simulation config for: ${roleOrType}`);
+    if (!this.simulationConfig || !this.simulationConfig[roleOrType]) {
+      return 0;
     }
     const value = this.simulationConfig[roleOrType][paramName];
-    if (value === undefined) {
-      throw new Error(`No default value for param: ${paramName} in ${roleOrType}`);
-    }
-    return value;
+    return value !== undefined ? value : 0;
   }
 
   glyphInfoUpdated(glyphInfo: GlyphInfo) {


### PR DESCRIPTION
Error handling for SBML export and Model tab frontend-backend connection.

- Show error message in Model tab when simulation config fails to load                                       
- Return 400 for unrecognized API paths to backend                         
- Sanitize null event IDs in SBML export                                                                     
- Null-safe error messages in Convert exception handler