### PR TITLE
Model data and events persist in SBOL exports and imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# System
+.DS_Store
 desktop.ini
+
+# IDE
+.vscode/tasks.json
+.vscode/java-formatter.xml
+
+# Java
 *.war
 *.class
-.vscode/tasks.json 

--- a/SBOLCanvasBackend/src/data/EventInfo.java
+++ b/SBOLCanvasBackend/src/data/EventInfo.java
@@ -1,47 +1,26 @@
 package data;
 
+import java.util.Hashtable;
+
 public class EventInfo extends Info {
 
-	private String name;
-	private String targetSpecies;
-	private double delay; // Defaults to 0
-	private double assignmentValue; // Defaults to 0
+	private Hashtable<String, Object> simulationData;
 
 	@Override
 	public String getFullURI() {
+		if (uriPrefix == null || displayID == null) {
+			throw new IllegalStateException(
+					"EventInfo has null uriPrefix or displayID (uriPrefix=" + uriPrefix + ", displayID=" + displayID + ")");
+		}
 		return uriPrefix + "/" + displayID;
 	}
 
-	public String getName() {
-		return name;
+	public Hashtable<String, Object> getSimulationData() {
+		return simulationData;
 	}
 
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public double getDelay() {
-		return delay;
-	}
-
-	public void setDelay(double delay) {
-		this.delay = delay;
-	}
-
-	public String getTargetSpecies() {
-		return targetSpecies;
-	}
-
-	public void setTargetSpecies(String targetSpecies) {
-		this.targetSpecies = targetSpecies;
-	}
-
-	public double getAssignmentValue() {
-		return assignmentValue;
-	}
-
-	public void setAssignmentValue(double assignmentValue) {
-		this.assignmentValue = assignmentValue;
+	public void setSimulationData(Hashtable<String, Object> simulationData) {
+		this.simulationData = simulationData;
 	}
 
 }

--- a/SBOLCanvasBackend/src/utils/Converter.java
+++ b/SBOLCanvasBackend/src/utils/Converter.java
@@ -5,14 +5,25 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.xml.namespace.QName;
 
+import org.sbolstandard.core2.Annotation;
+import org.sbolstandard.core2.Identified;
+import org.sbolstandard.core2.SBOLValidationException;
+
 import org.w3c.dom.Document;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import com.mxgraph.io.mxCodec;
 import com.mxgraph.io.mxCodecRegistry;
+import com.mxgraph.io.mxObjectCodec;
 import com.mxgraph.model.mxCell;
 import com.mxgraph.model.mxGraphModel;
 import com.mxgraph.model.mxGraphModel.Filter;
@@ -52,11 +63,70 @@ public class Converter {
 	protected static final String STYLE_MODULE_VIEW = "moduleViewCell";
 	protected static final String STYLE_COMPONENT_VIEW = "componentViewCell";
 	protected static final String STYLE_INTERACTION_NODE = "interactionNodeGlyph";
+	protected static final String STYLE_EVENT = "eventGlyph";
 
 	static {
 		// Necessary for encoding/decoding GlyphInfo and InteractionInfo
 		mxCodecRegistry.addPackage("data");
+
+		// Custom codec for GlyphInfo and InteractionInfo simulation data
+		// Default mxObjectCodec decodes as an ArrayList, losing the keys
+		mxCodecRegistry.register(createSimulationDataCodec(
+				new GlyphInfo(), GlyphInfo.class, GlyphInfo::setSimulationData));
+		mxCodecRegistry.register(createSimulationDataCodec(
+				new InteractionInfo(), InteractionInfo.class, InteractionInfo::setSimulationData));
+		mxCodecRegistry.register(createSimulationDataCodec(
+				new EventInfo(), EventInfo.class, EventInfo::setSimulationData));
 	};
+
+	/**
+	 * mxObjectCodec that decodes to a Hashtable instead of an ArrayList.
+	 *
+	 * @param template    the template object (e.g., new GlyphInfo())
+	 * @param targetType  the expected runtime class of the decoded object
+	 * @param setter      applies the parsed Hashtable to the decoded object
+	 */
+	private static <T> mxObjectCodec createSimulationDataCodec(
+			Object template, Class<T> targetType,
+			java.util.function.BiConsumer<T, Hashtable<String, Object>> setter) {
+		return new mxObjectCodec(template) {
+			@Override
+			protected void decodeChild(mxCodec dec, Node child, Object obj) {
+				if (child instanceof Element) {
+					Element elem = (Element) child;
+					if ("Array".equals(child.getNodeName())
+							&& "simulationData".equals(elem.getAttribute("as"))
+							&& targetType.isInstance(obj)) {
+						setter.accept(targetType.cast(obj), parseSimulationDataNode(child));
+						return;
+					}
+				}
+				super.decodeChild(dec, child, obj);
+			}
+		};
+	}
+
+	/**
+	 * Parses an <Array> XML node with <add value="..." as="key"/> children
+	 * into a Hashtable. The frontend encodes simulationData this way, but the
+	 * default mxCodec decodes <Array> as ArrayList, losing the key names.
+	 */
+	private static Hashtable<String, Object> parseSimulationDataNode(Node arrayNode) {
+		Hashtable<String, Object> data = new Hashtable<>();
+		NodeList children = arrayNode.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node child = children.item(i);
+			if (child instanceof Element && "add".equals(child.getNodeName())) {
+				Element addElem = (Element) child;
+				String key = addElem.getAttribute("as");
+				String value = addElem.getAttribute("value");
+				if (key != null && !key.isEmpty() && value != null) {
+					data.put(key, value);
+				}
+			}
+		}
+		return data;
+	}
 
 	protected Hashtable<String, Info> infoDict;
 	protected Hashtable<String, CombinatorialInfo> combinatorialDict;
@@ -64,33 +134,30 @@ public class Converter {
 	protected Hashtable<String, EventInfo> eventDict;
 	protected LayoutHelper layoutHelper;
 
+	protected Converter() {
+		infoDict = new Hashtable<>();
+		combinatorialDict = new Hashtable<>();
+		interactionDict = new Hashtable<>();
+		eventDict = new Hashtable<>();
+	}
+
 	/**
 	 * Filters mxCells that contain "textBox" in the style string
 	 */
 	static Filter textBoxFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_TEXTBOX);
+			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && ((mxCell) arg0).getStyle().contains(STYLE_TEXTBOX);
 		}
 	};
 
 	/**
-	 * Filters mxCells that contain "protein" in the style string
-	 */
-	static Filter proteinFilter = new Filter() {
-		@Override
-		public boolean filter(Object arg0) {
-			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_MOLECULAR_SPECIES);
-		}
-	};
-
-	/**
-	 * Filters mxCells that contain "molecularSpeciesGlyph" in the style string
+	 * Filters mxCells with molecularSpeciesGlyph style (proteins, small molecules, complexes, etc.)
 	 */
 	static Filter molecularSpeciesFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_MOLECULAR_SPECIES);
+			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && ((mxCell) arg0).getStyle().contains(STYLE_MOLECULAR_SPECIES);
 		}
 	};
 
@@ -100,7 +167,7 @@ public class Converter {
 	static Filter moduleFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_MODULE);
+			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && ((mxCell) arg0).getStyle().contains(STYLE_MODULE);
 		}
 	};
 
@@ -110,7 +177,7 @@ public class Converter {
 	static Filter containerFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			return (arg0 instanceof mxCell && (((mxCell) arg0).getStyle().contains(STYLE_CIRCUIT_CONTAINER)) && (((mxCell) arg0).getChildCount() > 1));
+			return (arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && (((mxCell) arg0).getStyle().contains(STYLE_CIRCUIT_CONTAINER)) && (((mxCell) arg0).getChildCount() > 1));
 		}
 	};
 
@@ -120,7 +187,7 @@ public class Converter {
 	static Filter backboneFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_BACKBONE);
+			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && ((mxCell) arg0).getStyle().contains(STYLE_BACKBONE);
 		}
 	};
 
@@ -131,7 +198,7 @@ public class Converter {
 	static Filter sequenceFeatureFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			if (arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_SEQUENCE_FEATURE)) {
+			if (arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && ((mxCell) arg0).getStyle().contains(STYLE_SEQUENCE_FEATURE)) {
 				if (((mxCell) arg0).getStyle().contains("Cir (Circular Backbone Left)")) {
 					return false;
 				}
@@ -144,7 +211,7 @@ public class Converter {
 	static Filter interactionNodeFilter = new Filter() {
 		@Override
 		public boolean filter(Object arg0) {
-			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle().contains(STYLE_INTERACTION_NODE);
+			return arg0 instanceof mxCell && ((mxCell) arg0).getStyle() != null && ((mxCell) arg0).getStyle().contains(STYLE_INTERACTION_NODE);
 		}
 	};
 
@@ -170,6 +237,55 @@ public class Converter {
 		return new QName(URI_PREFIX, name, ANN_PREFIX);
 	}
 
+	/**
+	 * Sanitize a string to be a valid XML NCName for use as a QName local part.
+	 * Characters not valid in NCNames are encoded as _xHHHH_ where HHHH is 4-digit uppercase hex.
+	 * Needed because InteractionInfo simulationData keys can contain full URIs
+	 * (e.g., "nc_https://sbolcanvas.org/FKha2kkU/1") which are invalid XML element names.
+	 *
+	 * @see MxToSBML#sanitizeId for SBML SId sanitization (different spec, different rules)
+	 */
+	static String sanitizeAnnotationKey(String key) {
+		if (key == null || key.isEmpty()) return key;
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < key.length(); i++) {
+			char c = key.charAt(i);
+			if (i == 0 ? (Character.isLetter(c) || c == '_')
+					   : (Character.isLetterOrDigit(c) || c == '.' || c == '-' || c == '_')) {
+				sb.append(c);
+			} else {
+				sb.append("_x").append(String.format("%04X", (int) c)).append("_");
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Reverse sanitizeAnnotationKey: decode _xHHHH_ sequences back to characters.
+	 */
+	static String desanitizeAnnotationKey(String key) {
+		if (key == null || key.isEmpty()) return key;
+		StringBuilder sb = new StringBuilder();
+		int i = 0;
+		while (i < key.length()) {
+			if (i + 6 < key.length() && key.charAt(i) == '_' && key.charAt(i + 1) == 'x'
+					&& isHexDigit(key.charAt(i + 2)) && isHexDigit(key.charAt(i + 3))
+					&& isHexDigit(key.charAt(i + 4)) && isHexDigit(key.charAt(i + 5))
+					&& key.charAt(i + 6) == '_') {
+				sb.append((char) Integer.parseInt(key.substring(i + 2, i + 6), 16));
+				i += 7;
+			} else {
+				sb.append(key.charAt(i));
+				i++;
+			}
+		}
+		return sb.toString();
+	}
+
+	private static boolean isHexDigit(char c) {
+		return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+	}
+
 	// Helpers shared between MxToSBOL and MxToSBML
 
 	/**
@@ -185,6 +301,23 @@ public class Converter {
 		Document document = mxXmlUtils.parseXml(mxUtils.readInputStream(graphStream));
 		mxCodec codec = new mxCodec(document);
 		codec.decode(document.getDocumentElement(), graph.getModel());
+		return graph;
+	}
+
+	/**
+	 * Parses an mxGraph from an input stream and loads all four dictionaries
+	 * (info, combinatorial, interaction, event) from cell 0's data container.
+	 */
+	@SuppressWarnings("unchecked")
+	protected mxGraph loadGraphAndDictionaries(InputStream graphStream) throws IOException {
+		mxGraph graph = parseGraph(graphStream);
+		mxGraphModel model = (mxGraphModel) graph.getModel();
+		mxCell cell0 = (mxCell) model.getCell("0");
+		ArrayList<Object> dataContainer = (ArrayList<Object>) cell0.getValue();
+		infoDict = loadDictionary(dataContainer, INFO_DICT_INDEX);
+		combinatorialDict = loadDictionary(dataContainer, COMBINATORIAL_DICT_INDEX);
+		interactionDict = loadDictionary(dataContainer, INTERACTION_DICT_INDEX);
+		loadEventDictOrEmpty(dataContainer);
 		return graph;
 	}
 
@@ -220,6 +353,57 @@ public class Converter {
 			return dict;
 		} else {
 			return (Hashtable<String, T>) dataContainer.get(dictionaryIndex);
+		}
+	}
+
+	/**
+	 * Write simulation data as a nested SBOL annotation on the given Identified object.
+	 * Keys are sorted for deterministic output; URI-containing keys are sanitized for XML.
+	 *
+	 * @param identityPrefix the parent's displayId (not full URI) — used to build the
+	 *                       nested annotation's displayId, which must be a valid SBOL
+	 *                       identifier (alphanumeric + underscore, sbol-10204)
+	 */
+	static void writeSimulationAnnotations(Identified parent, Hashtable<String, Object> simulationData,
+			String identityPrefix) throws SBOLValidationException {
+		if (simulationData == null || simulationData.isEmpty()) return;
+		List<Annotation> annList = new ArrayList<Annotation>();
+		for (String key : new TreeSet<>(simulationData.keySet())) {
+			annList.add(new Annotation(createQName(sanitizeAnnotationKey(key)), simulationData.get(key).toString()));
+		}
+		parent.createAnnotation(
+				createQName("simulationData"),
+				createQName("SimulationData"),
+				identityPrefix + "_SimulationData",
+				annList);
+	}
+
+	/**
+	 * Read simulation data from a nested SBOL annotation on the given Identified object.
+	 * Returns an empty Hashtable if no simulationData annotation exists.
+	 */
+	static Hashtable<String, Object> readSimulationAnnotations(Identified identified) {
+		for (Annotation annotation : identified.getAnnotations()) {
+			if (annotation.getQName().getLocalPart().equals("simulationData")) {
+				Hashtable<String, Object> simData = new Hashtable<String, Object>();
+				for (Annotation child : annotation.getAnnotations()) {
+					simData.put(desanitizeAnnotationKey(child.getQName().getLocalPart()), child.getStringValue());
+				}
+				return simData;
+			}
+		}
+		return new Hashtable<>();
+	}
+
+	/**
+	 * Load eventDict from the dataContainer, falling back to an empty Hashtable
+	 * for designs created before events were added.
+	 */
+	protected void loadEventDictOrEmpty(ArrayList<Object> dataContainer) {
+		if (dataContainer.size() > EVENT_DICT_INDEX) {
+			eventDict = loadDictionary(dataContainer, EVENT_DICT_INDEX);
+		} else {
+			eventDict = new Hashtable<>();
 		}
 	}
 

--- a/SBOLCanvasBackend/src/utils/MxToSBML.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBML.java
@@ -140,16 +140,15 @@ public class MxToSBML extends Converter {
 	private HashSet<String> usedIds = new HashSet<>();
 	private LayoutBounds layoutBounds = new LayoutBounds();
 	private HashMap<String, SpeciesData> glyphToSpeciesData = new HashMap<>();
+	private HashMap<String, String> displayNameToSpeciesId = new HashMap<>();
+	private HashMap<String, String> reactionToPromoterId = new HashMap<>();
 
 	public MxToSBML() {
 		this(null);
 	}
 
 	public MxToSBML(HashMap<String, String> userTokens) {
-		infoDict = new Hashtable<String, Info>();
-		combinatorialDict = new Hashtable<String, CombinatorialInfo>();
-		interactionDict = new Hashtable<String, InteractionInfo>();
-		eventDict = new Hashtable<String, EventInfo>();
+		super();
 		this.userTokens = userTokens;
 	}
 
@@ -164,17 +163,10 @@ public class MxToSBML extends Converter {
 		org.sbml.jsbml.TidySBMLWriter.write(document, sbmlStream, "SBOLCanvas", "1.0", ' ', (short) 2);
 	}
 
-	@SuppressWarnings("unchecked")
 	private SBMLDocument setupDocument(InputStream graphStream) throws IOException,
 			TransformerFactoryConfigurationError, TransformerException, URISyntaxException {
-		mxGraph graph = parseGraph(graphStream);
+		mxGraph graph = loadGraphAndDictionaries(graphStream);
 		mxGraphModel model = (mxGraphModel) graph.getModel();
-		mxCell cell0 = (mxCell) model.getCell("0");
-		ArrayList<Object> dataContainer = (ArrayList<Object>) cell0.getValue();
-		infoDict = loadDictionary(dataContainer, INFO_DICT_INDEX);
-		combinatorialDict = loadDictionary(dataContainer, COMBINATORIAL_DICT_INDEX);
-		interactionDict = loadDictionary(dataContainer, INTERACTION_DICT_INDEX);
-		eventDict = loadDictionary(dataContainer, EVENT_DICT_INDEX);
 
 		SBMLDocument document = new SBMLDocument(3, 2);
 		Model sbmlModel = document.createModel("sbolcanvas_model");
@@ -247,13 +239,14 @@ public class MxToSBML extends Converter {
 					promoterName = promoterInfo.getDisplayID();
 				}
 				String promoterId = sanitizeId(promoterName);
+				displayNameToSpeciesId.put(promoterName, promoterId);
 
 				Species promoterSpecies = sbmlModel.createSpecies(promoterId);
 				promoterSpecies.setCompartment("Cell");
 				promoterSpecies.setSBOTerm(590); // SBO:0000590 Logical element (promoter)
 
 				// Set initial amount from ng parameter
-				double ng = getParam(promoterInfo.getSimulationData(), "ng", SequenceOntology.PROMOTER, "promoter '" + promoterName + "'");
+				double ng = getParam(promoterInfo.getSimulationData(), SBOLData.PARAM_NG, SequenceOntology.PROMOTER, "promoter '" + promoterName + "'");
 				promoterSpecies.setInitialAmount(ng);
 				promoterSpecies.setHasOnlySubstanceUnits(true);
 				promoterSpecies.setConstant(false);
@@ -339,6 +332,7 @@ public class MxToSBML extends Converter {
 			GlyphInfo promoterInfo = (GlyphInfo) infoDict.get(tuData.promoterGlyph.getValue());
 			String promoterId = tuData.promoterSpecies.getId();
 			String reactionId = "Production_" + promoterId;
+			reactionToPromoterId.put(reactionId, promoterId);
 
 			Reaction reaction = sbmlModel.createReaction(reactionId);
 			reaction.setReversible(false);
@@ -348,9 +342,12 @@ public class MxToSBML extends Converter {
 			ModifierSpeciesReference promoterModifier = reaction.createModifier(tuData.promoterSpecies);
 			promoterModifier.setSBOTerm(598); // SBO:0000598 Promoter
 
-			double np = getParam(promoterInfo.getSimulationData(), "np", SequenceOntology.PROMOTER, "promoter '" + promoterId + "'");
+			double np = getParam(promoterInfo.getSimulationData(), SBOLData.PARAM_NP, SequenceOntology.PROMOTER, "promoter '" + promoterId + "'");
 			for (mxCell productionEdge : tuData.productionEdges) {
 				mxCell targetCell = (mxCell) productionEdge.getTarget();
+				if (targetCell == null) {
+					throw new IllegalArgumentException("Production edge has no target cell (disconnected edge)");
+				}
 				SpeciesData productData = glyphToSpeciesData.get((String) targetCell.getValue());
 				if (productData == null) {
 					throw new IllegalArgumentException("Product species not found for production edge");
@@ -487,10 +484,10 @@ public class MxToSBML extends Converter {
 
 		Hashtable<String, Object> promoterSimData = promoterInfo.getSimulationData();
 		String promoterContext = "promoter '" + promoterId + "'";
-		double ko = getParam(promoterSimData, "ko", SequenceOntology.PROMOTER, promoterContext);
-		double Ko_f = getParam(promoterSimData, "Ko_f", SequenceOntology.PROMOTER, promoterContext);
-		double Ko_r = getParam(promoterSimData, "Ko_r", SequenceOntology.PROMOTER, promoterContext);
-		double nr = getParam(promoterSimData, "nr", SequenceOntology.PROMOTER, promoterContext);
+		double ko = getParam(promoterSimData, SBOLData.PARAM_KO, SequenceOntology.PROMOTER, promoterContext);
+		double Ko_f = getParam(promoterSimData, SBOLData.PARAM_KO_F, SequenceOntology.PROMOTER, promoterContext);
+		double Ko_r = getParam(promoterSimData, SBOLData.PARAM_KO_R, SequenceOntology.PROMOTER, promoterContext);
+		double nr = getParam(promoterSimData, SBOLData.PARAM_NR, SequenceOntology.PROMOTER, promoterContext);
 
 		law.createLocalParameter("ko").setValue(ko);
 		law.createLocalParameter("ko_f").setValue(Ko_f);
@@ -507,9 +504,9 @@ public class MxToSBML extends Converter {
 		InteractionInfo repInfo = (InteractionInfo) interactionDict.get(repressorEdge.getValue());
 		Hashtable<String, Object> repSimData = repInfo != null ? repInfo.getSimulationData() : null;
 		String repContext = "inhibition from '" + repId + "' to '" + promoterId + "'";
-		double Kr_f = getParam(repSimData, "Kr_f", SystemsBiologyOntology.INHIBITION, repContext);
-		double Kr_r = getParam(repSimData, "Kr_r", SystemsBiologyOntology.INHIBITION, repContext);
-		double nc = getParam(repSimData, "nc", SystemsBiologyOntology.INHIBITION, repContext);
+		double Kr_f = getParam(repSimData, SBOLData.PARAM_KR_F, SystemsBiologyOntology.INHIBITION, repContext);
+		double Kr_r = getParam(repSimData, SBOLData.PARAM_KR_R, SystemsBiologyOntology.INHIBITION, repContext);
+		double nc = getParam(repSimData, SBOLData.PARAM_NC, SystemsBiologyOntology.INHIBITION, repContext);
 
 		String p_Krf = "kr_f_" + repId;
 		String p_Krr = "kr_r_" + repId;
@@ -546,13 +543,13 @@ public class MxToSBML extends Converter {
 
 		Hashtable<String, Object> promoterSimData = promoterInfo.getSimulationData();
 		String promoterContext = "promoter '" + promoterId + "'";
-		double kb = getParam(promoterSimData, "kb", SequenceOntology.PROMOTER, promoterContext);
-		double ka = getParam(promoterSimData, "ka", SequenceOntology.PROMOTER, promoterContext);
-		double Ko_f = getParam(promoterSimData, "Ko_f", SequenceOntology.PROMOTER, promoterContext);
-		double Ko_r = getParam(promoterSimData, "Ko_r", SequenceOntology.PROMOTER, promoterContext);
-		double Kao_f = getParam(promoterSimData, "Kao_f", SequenceOntology.PROMOTER, promoterContext);
-		double Kao_r = getParam(promoterSimData, "Kao_r", SequenceOntology.PROMOTER, promoterContext);
-		double nr = getParam(promoterSimData, "nr", SequenceOntology.PROMOTER, promoterContext);
+		double kb = getParam(promoterSimData, SBOLData.PARAM_KB, SequenceOntology.PROMOTER, promoterContext);
+		double ka = getParam(promoterSimData, SBOLData.PARAM_KA, SequenceOntology.PROMOTER, promoterContext);
+		double Ko_f = getParam(promoterSimData, SBOLData.PARAM_KO_F, SequenceOntology.PROMOTER, promoterContext);
+		double Ko_r = getParam(promoterSimData, SBOLData.PARAM_KO_R, SequenceOntology.PROMOTER, promoterContext);
+		double Kao_f = getParam(promoterSimData, SBOLData.PARAM_KAO_F, SequenceOntology.PROMOTER, promoterContext);
+		double Kao_r = getParam(promoterSimData, SBOLData.PARAM_KAO_R, SequenceOntology.PROMOTER, promoterContext);
+		double nr = getParam(promoterSimData, SBOLData.PARAM_NR, SequenceOntology.PROMOTER, promoterContext);
 
 		law.createLocalParameter("kb").setValue(kb);
 		law.createLocalParameter("ka").setValue(ka);
@@ -572,9 +569,9 @@ public class MxToSBML extends Converter {
 		InteractionInfo actInfo = (InteractionInfo) interactionDict.get(activatorEdge.getValue());
 		Hashtable<String, Object> actSimData = actInfo != null ? actInfo.getSimulationData() : null;
 		String actContext = "stimulation from '" + actId + "' to '" + promoterId + "'";
-		double Ka_f = getParam(actSimData, "Ka_f", SystemsBiologyOntology.STIMULATION, actContext);
-		double Ka_r = getParam(actSimData, "Ka_r", SystemsBiologyOntology.STIMULATION, actContext);
-		double nc = getParam(actSimData, "nc", SystemsBiologyOntology.STIMULATION, actContext);
+		double Ka_f = getParam(actSimData, SBOLData.PARAM_KA_F, SystemsBiologyOntology.STIMULATION, actContext);
+		double Ka_r = getParam(actSimData, SBOLData.PARAM_KA_R, SystemsBiologyOntology.STIMULATION, actContext);
+		double nc = getParam(actSimData, SBOLData.PARAM_NC, SystemsBiologyOntology.STIMULATION, actContext);
 
 		String p_Kaf = "ka_f_" + actId;
 		String p_Kar = "ka_r_" + actId;
@@ -686,7 +683,7 @@ public class MxToSBML extends Converter {
 
 	private void createProductionEdges(Layout layout, Reaction reaction,
 			Map<String, Point2D> speciesCenter) {
-		String promoterId = reaction.getId().substring("Production_".length());
+		String promoterId = reactionToPromoterId.get(reaction.getId());
 
 		for (SpeciesReference product : reaction.getListOfProducts()) {
 			createEdge(layout, promoterId, product.getSpecies(), "Production", speciesCenter);
@@ -704,6 +701,9 @@ public class MxToSBML extends Converter {
 
 	private void createComplexEdges(Layout layout, Reaction reaction,
 			Map<String, Point2D> speciesCenter) {
+		if (reaction.getListOfProducts().size() == 0) {
+			return;
+		}
 		String productId = reaction.getProduct(0).getSpecies();
 
 		for (SpeciesReference reactant : reaction.getListOfReactants()) {
@@ -715,6 +715,10 @@ public class MxToSBML extends Converter {
 	 * Add SBOLCanvas Glyph positions to the SBML Layout.
 	 */
 	private void createVisualLayout(Model sbmlModel) {
+		if (glyphToSpeciesData.isEmpty()) {
+			return; // No species — layout bounds are uninitialized
+		}
+
 		Layout layout = setupLayout(sbmlModel);
 		Map<String, Point2D> speciesCenter = createSpeciesGlyphs(layout);
 
@@ -738,22 +742,27 @@ public class MxToSBML extends Converter {
 		}
 
 		for (EventInfo eventInfo : eventDict.values()) {
-			String targetSpecies = eventInfo.getTargetSpecies();
+			Hashtable<String, Object> simData = eventInfo.getSimulationData();
+			String context = "event '" + eventInfo.getDisplayID() + "'";
+
+			String targetSpecies = getStringParam(simData, SBOLData.PARAM_EVENT_TARGET_SPECIES);
 			if (targetSpecies == null || targetSpecies.isEmpty()) {
-				throw new IllegalArgumentException(
-						"Event '" + eventInfo.getDisplayID() + "' missing target species");
+				throw new IllegalArgumentException(context + " missing target species");
 			}
 
-			if (sbmlModel.getSpecies(targetSpecies) == null) {
+			// Resolve display name to SBML species ID. The user enters a display
+			// name (e.g., "LacI protein") but SBML uses sanitized IDs ("LacI_protein").
+			String speciesId = resolveSpeciesId(sbmlModel, targetSpecies, displayNameToSpeciesId);
+			if (speciesId == null) {
 				throw new IllegalArgumentException(
-						"Event '" + eventInfo.getDisplayID() + "' references unknown species '" + targetSpecies + "'");
+						context + " references unknown species '" + targetSpecies + "'");
 			}
 
-			String eventId = eventInfo.getName();
-			if (eventId == null || eventId.isEmpty()) {
-				eventId = eventInfo.getDisplayID();
+			String eventName = getStringParam(simData, SBOLData.PARAM_EVENT_NAME);
+			if (eventName == null || eventName.isEmpty()) {
+				eventName = eventInfo.getDisplayID();
 			}
-			Event event = sbmlModel.createEvent(sanitizeId(eventId));
+			Event event = sbmlModel.createEvent(sanitizeId(eventName));
 			event.setUseValuesFromTriggerTime(false);
 
 			// Trigger hardcoded to true. TODO: add conditional triggers
@@ -762,15 +771,27 @@ public class MxToSBML extends Converter {
 			trigger.setPersistent(false);
 			trigger.setMath(new ASTNode(ASTNode.Type.CONSTANT_TRUE));
 
+			// Delay: default to 0.0 if not specified
+			double delayVal = 0.0;
+			if (simData != null && simData.containsKey(SBOLData.PARAM_EVENT_DELAY)) {
+				delayVal = extractDouble(simData.get(SBOLData.PARAM_EVENT_DELAY), 0.0,
+						"delay on " + context);
+			}
 			Delay delay = event.createDelay();
 			ASTNode delayMath = new ASTNode(ASTNode.Type.REAL);
-			delayMath.setValue(eventInfo.getDelay());
+			delayMath.setValue(delayVal);
 			delay.setMath(delayMath);
 
+			// Assignment value: default to 0.0 if not specified
+			double assignVal = 0.0;
+			if (simData != null && simData.containsKey(SBOLData.PARAM_EVENT_ASSIGNMENT_VALUE)) {
+				assignVal = extractDouble(simData.get(SBOLData.PARAM_EVENT_ASSIGNMENT_VALUE), 0.0,
+						"assignment value on " + context);
+			}
 			EventAssignment assignment = event.createEventAssignment();
-			assignment.setVariable(targetSpecies);
+			assignment.setVariable(speciesId);
 			ASTNode valueMath = new ASTNode(ASTNode.Type.REAL);
-			valueMath.setValue(eventInfo.getAssignmentValue());
+			valueMath.setValue(assignVal);
 			assignment.setMath(valueMath);
 		}
 	}
@@ -784,13 +805,18 @@ public class MxToSBML extends Converter {
 	 */
 	private Species createSpecies(Model model, mxCell glyph) {
 		GlyphInfo glyphInfo = (GlyphInfo) infoDict.get(glyph.getValue());
+		if (glyphInfo == null) {
+			throw new IllegalArgumentException(
+					"No GlyphInfo found for species glyph '" + glyph.getValue() + "' (orphaned glyph?)");
+		}
 
 		// SBML ID becomes the label. Pick Name over DisplayID
-		String speciesId = glyphInfo.getDisplayID();
+		String displayName = glyphInfo.getDisplayID();
 		if (glyphInfo.getName() != null && !glyphInfo.getName().isEmpty()) {
-			speciesId = glyphInfo.getName();
+			displayName = glyphInfo.getName();
 		}
-		speciesId = sanitizeId(speciesId);
+		String speciesId = sanitizeId(displayName);
+		displayNameToSpeciesId.put(displayName, speciesId);
 
 		Species species = model.createSpecies(speciesId);
 		species.setCompartment("Cell");
@@ -832,17 +858,8 @@ public class MxToSBML extends Converter {
 
 		double initialAmount = 0.0;
 		if (glyphInfo.getSimulationData() != null && glyphInfo.getSimulationData().containsKey("initialAmount")) {
-			Object iaValue = glyphInfo.getSimulationData().get("initialAmount");
-			if (iaValue instanceof Number) {
-				initialAmount = ((Number) iaValue).doubleValue();
-			} else if (iaValue instanceof String) {
-				try {
-					initialAmount = Double.parseDouble((String) iaValue);
-				} catch (NumberFormatException e) {
-					throw new IllegalArgumentException(
-							"Invalid initialAmount value for species " + glyphInfo.getDisplayID() + ": " + iaValue, e);
-				}
-			}
+			initialAmount = extractDouble(glyphInfo.getSimulationData().get("initialAmount"), 0.0,
+					"initialAmount on species '" + glyphInfo.getDisplayID() + "'");
 		}
 		species.setInitialAmount(initialAmount);
 		species.setHasOnlySubstanceUnits(true); // Amount of molecules, not concentration
@@ -860,6 +877,9 @@ public class MxToSBML extends Converter {
 	 */
 	private void createDegradationReaction(Model model, mxCell edge, InteractionInfo info, mxGraphModel graphModel) {
 		mxCell source = (mxCell) edge.getSource();
+		if (source == null) {
+			throw new IllegalArgumentException("Degradation edge has no source cell (disconnected edge)");
+		}
 		SpeciesData sourceData = glyphToSpeciesData.get((String) source.getValue());
 		if (sourceData == null) {
 			throw new IllegalArgumentException("Source species not found for degradation edge");
@@ -878,7 +898,7 @@ public class MxToSBML extends Converter {
 
 		KineticLaw law = reaction.createKineticLaw();
 		LocalParameter kd = law.createLocalParameter("kd");
-		kd.setValue(getParam(info.getSimulationData(), "kd", SystemsBiologyOntology.DEGRADATION, "degradation of '" + speciesId + "'"));
+		kd.setValue(getParam(info.getSimulationData(), SBOLData.PARAM_KD, SystemsBiologyOntology.DEGRADATION, "degradation of '" + speciesId + "'"));
 		try {
 			law.setMath(new FormulaParser(
 					new ByteArrayInputStream(("kd * " + speciesId).getBytes(StandardCharsets.UTF_8))).parse());
@@ -902,6 +922,9 @@ public class MxToSBML extends Converter {
 
 		mxCell outEdge = (mxCell) outgoing[0];
 		mxCell target = (mxCell) outEdge.getTarget();
+		if (target == null) {
+			throw new IllegalArgumentException("Complex formation product edge has no target cell (disconnected edge)");
+		}
 		SpeciesData productData = glyphToSpeciesData.get((String) target.getValue());
 		if (productData == null) {
 			throw new IllegalArgumentException("Product species not found for complex formation");
@@ -922,6 +945,9 @@ public class MxToSBML extends Converter {
 		for (Object obj : incoming) {
 			mxCell inEdge = (mxCell) obj;
 			mxCell source = (mxCell) inEdge.getSource();
+			if (source == null) {
+				throw new IllegalArgumentException("Complex formation reactant edge has no source cell (disconnected edge)");
+			}
 			SpeciesData sourceData = glyphToSpeciesData.get((String) source.getValue());
 			if (sourceData == null) {
 				throw new IllegalArgumentException("Reactant species not found for complex formation edge");
@@ -935,7 +961,7 @@ public class MxToSBML extends Converter {
 			InteractionInfo edgeInfo = (InteractionInfo) interactionDict.get(inEdge.getValue());
 			Hashtable<String, Object> edgeSimData = edgeInfo != null ? edgeInfo.getSimulationData() : null;
 			String sourceURI = (String) source.getValue();
-			double nc = getKeyedParam(edgeSimData, "nc", sourceURI, SystemsBiologyOntology.NON_COVALENT_BINDING,
+			double nc = getKeyedParam(edgeSimData, SBOLData.PARAM_NC, sourceURI, SystemsBiologyOntology.NON_COVALENT_BINDING,
 					"complex formation of '" + productId + "' (reactant '" + speciesId + "')");
 
 			String ncParam = "nc_" + speciesId;
@@ -949,11 +975,11 @@ public class MxToSBML extends Converter {
 
 		rateLaw.append(" - kc_r * ").append(productId);
 
-		law.createLocalParameter("Kc_f".toLowerCase()).setValue(
-				getParam(info.getSimulationData(), "Kc_f", SystemsBiologyOntology.NON_COVALENT_BINDING,
+		law.createLocalParameter(SBOLData.PARAM_KC_F.toLowerCase()).setValue(
+				getParam(info.getSimulationData(), SBOLData.PARAM_KC_F, SystemsBiologyOntology.NON_COVALENT_BINDING,
 						"complex formation of '" + productId + "'"));
-		law.createLocalParameter("Kc_r".toLowerCase()).setValue(
-				getParam(info.getSimulationData(), "Kc_r", SystemsBiologyOntology.NON_COVALENT_BINDING,
+		law.createLocalParameter(SBOLData.PARAM_KC_R.toLowerCase()).setValue(
+				getParam(info.getSimulationData(), SBOLData.PARAM_KC_R, SystemsBiologyOntology.NON_COVALENT_BINDING,
 						"complex formation of '" + productId + "'"));
 
 		try {
@@ -962,6 +988,25 @@ public class MxToSBML extends Converter {
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to parse complex formation kinetic law: " + e.getMessage(), e);
 		}
+	}
+
+	/**
+	 * Extracts a double from a value that may be a Number, a numeric String,
+	 * or null. Returns defaultVal for null; throws for non-numeric values.
+	 */
+	private static double extractDouble(Object val, double defaultVal, String context) {
+		if (val == null) return defaultVal;
+		if (val instanceof Number) return ((Number) val).doubleValue();
+		if (val instanceof String) {
+			try {
+				return Double.parseDouble((String) val);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(
+						"Non-numeric value for " + context + ": '" + val + "'", e);
+			}
+		}
+		throw new IllegalArgumentException(
+				"Invalid type for " + context + ". Expected number, got: " + val.getClass().getSimpleName());
 	}
 
 	/**
@@ -974,17 +1019,21 @@ public class MxToSBML extends Converter {
 	 */
 	private double getParam(Hashtable<String, Object> simData, String paramName, URI type, String context) {
 		if (simData != null && simData.containsKey(paramName)) {
-			Object val = simData.get(paramName);
-			if (val instanceof Number) {
-				return ((Number) val).doubleValue();
-			} else if (val instanceof String) {
-				return Double.parseDouble((String) val);
-			}
-			throw new IllegalArgumentException(
-					"Invalid type for parameter '" + paramName + "' on " + context +
-							". Expected a number but got: " + val.getClass().getSimpleName());
+			// default unreachable -- Hashtable forbids null values
+			return extractDouble(simData.get(paramName), 0.0,
+					"parameter '" + paramName + "' on " + context);
 		}
 		return getDefaultValue(type, paramName, context);
+	}
+
+	/**
+	 * Gets a string simulation parameter from simulationData.
+	 * Returns null if the key is missing or the value is null.
+	 */
+	private String getStringParam(Hashtable<String, Object> simData, String paramName) {
+		if (simData == null || !simData.containsKey(paramName)) return null;
+		Object val = simData.get(paramName);
+		return val != null ? val.toString() : null;
 	}
 
 	/**
@@ -1000,12 +1049,9 @@ public class MxToSBML extends Converter {
 			String context) {
 		String keyedParamName = paramName + "_" + keyURI;
 		if (simData != null && simData.containsKey(keyedParamName)) {
-			Object val = simData.get(keyedParamName);
-			if (val instanceof Number) {
-				return ((Number) val).doubleValue();
-			} else if (val instanceof String) {
-				return Double.parseDouble((String) val);
-			}
+			// default unreachable -- Hashtable forbids null values
+			return extractDouble(simData.get(keyedParamName), 0.0,
+					"parameter '" + keyedParamName + "' on " + context);
 		}
 		return getDefaultValue(type, paramName, context);
 	}
@@ -1044,6 +1090,32 @@ public class MxToSBML extends Converter {
 	}
 
 	/**
+	 * Resolve a user-entered species name to its SBML species ID.
+	 * Tries: direct SBML ID match, then display name lookup, then SBML name match.
+	 *
+	 * @return The resolved SBML species ID, or null if no match found
+	 */
+	private static String resolveSpeciesId(Model sbmlModel, String targetSpecies,
+			Map<String, String> nameToIdMap) {
+		// Direct SBML ID match (user typed the sanitized ID)
+		if (sbmlModel.getSpecies(targetSpecies) != null) {
+			return targetSpecies;
+		}
+		// Display name → SBML ID lookup (user typed the display name)
+		String mapped = nameToIdMap.get(targetSpecies);
+		if (mapped != null && sbmlModel.getSpecies(mapped) != null) {
+			return mapped;
+		}
+		// Fallback: match by SBML species name attribute
+		for (Species sp : sbmlModel.getListOfSpecies()) {
+			if (targetSpecies.equals(sp.getName())) {
+				return sp.getId();
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Sanitizes an ID to be a valid SBML SId. SBML SId must:
 	 * - be unique
 	 * - start with a letter or underscore
@@ -1051,6 +1123,7 @@ public class MxToSBML extends Converter {
 	 *
 	 * @param id The raw ID string
 	 * @return A valid, unique SBML SId
+	 * @see Converter#sanitizeAnnotationKey for XML NCName sanitization (different spec, different rules)
 	 */
 	private String sanitizeId(String id) {
 		if (id == null || id.isEmpty()) {

--- a/SBOLCanvasBackend/src/utils/MxToSBOL.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBOL.java
@@ -10,10 +10,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
-
 import javax.xml.namespace.QName;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactoryConfigurationError;
@@ -57,13 +55,14 @@ import com.mxgraph.util.mxXmlUtils;
 import com.mxgraph.view.mxGraph;
 
 import data.CanvasAnnotation;
+import data.CombinatorialInfo;
+import data.EventInfo;
 import data.Info;
 import data.GlyphInfo;
 import data.IdentifiedInfo;
 import data.InteractionInfo;
 import data.ModuleInfo;
 import data.VariableComponentInfo;
-import data.CombinatorialInfo;
 
 public class MxToSBOL extends Converter {
 
@@ -74,9 +73,7 @@ public class MxToSBOL extends Converter {
 	}
 
 	public MxToSBOL(HashMap<String, String> userTokens) {
-		infoDict = new Hashtable<String, Info>();
-		combinatorialDict = new Hashtable<String, CombinatorialInfo>();
-		interactionDict = new Hashtable<String, InteractionInfo>();
+		super();
 		this.userTokens = userTokens;
 	}
 
@@ -130,17 +127,11 @@ public class MxToSBOL extends Converter {
 		SBOLWriter.write(document, outputStream, SBOLDocument.RDFV1);
 	}
 
-	@SuppressWarnings("unchecked")
 	public SBOLDocument setupDocument(InputStream graphStream) throws IOException, URISyntaxException,
 			SBOLValidationException, TransformerFactoryConfigurationError, TransformerException, SynBioHubException {
 		// read in the mxGraph
-		mxGraph graph = parseGraph(graphStream);
+		mxGraph graph = loadGraphAndDictionaries(graphStream);
 		mxGraphModel model = (mxGraphModel) graph.getModel();
-		mxCell cell0 = (mxCell) model.getCell("0");
-		ArrayList<Object> dataContainer = (ArrayList<Object>) cell0.getValue();
-		infoDict = loadDictionary(dataContainer, INFO_DICT_INDEX);
-		combinatorialDict = loadDictionary(dataContainer, COMBINATORIAL_DICT_INDEX);
-		interactionDict = loadDictionary(dataContainer, INTERACTION_DICT_INDEX);
 
 		// cells may show up in the child array not based on their x location
 		enforceChildOrdering(model, graph);
@@ -196,10 +187,10 @@ public class MxToSBOL extends Converter {
 			mxCell[] circuitContainers = Arrays.stream(mxGraphModel.filterCells(viewChildren, containerFilter))
 					.toArray(mxCell[]::new);
 	
-			mxCell[] proteins = Arrays.stream(mxGraphModel.filterCells(viewChildren, proteinFilter))
+			mxCell[] molecularSpecies = Arrays.stream(mxGraphModel.filterCells(viewChildren, molecularSpeciesFilter))
 			.toArray(mxCell[]::new);
 
-			if (viewCell.getStyle().equals(STYLE_MODULE_VIEW) || circuitContainers.length > 1 || proteins.length > 0) {
+			if (viewCell.getStyle().equals(STYLE_MODULE_VIEW) || circuitContainers.length > 1 || molecularSpecies.length > 0) {
 				// module definitions
 				createModuleDefinition(document, graph, model, viewCell);
 			} else {
@@ -228,9 +219,9 @@ public class MxToSBOL extends Converter {
 			Object[] viewChildren = mxGraphModel.getChildCells(model, viewCell, true, true);
 			mxCell[] circuitContainers = Arrays.stream(mxGraphModel.filterCells(viewChildren, containerFilter))
 					.toArray(mxCell[]::new);
-			mxCell[] proteins = Arrays.stream(mxGraphModel.filterCells(viewChildren, proteinFilter))
+			mxCell[] molecularSpecies = Arrays.stream(mxGraphModel.filterCells(viewChildren, molecularSpeciesFilter))
 					.toArray(mxCell[]::new);
-			if (viewCell.getStyle().equals(STYLE_MODULE_VIEW) || circuitContainers.length > 1 || proteins.length > 0) {
+			if (viewCell.getStyle().equals(STYLE_MODULE_VIEW) || circuitContainers.length > 1 || molecularSpecies.length > 0) {
 				// module definitions
 				linkModuleDefinition(document, graph, model, viewCell);
 			}
@@ -245,6 +236,9 @@ public class MxToSBOL extends Converter {
 		for (CombinatorialInfo info : combinatorialDict.values()) {
 			linkCombinatorial(document, graph, model, info);
 		}
+
+		// write events as GenericTopLevel objects
+		writeEvents(document, graph);
 
 		return document;
 	}
@@ -265,7 +259,7 @@ public class MxToSBOL extends Converter {
 				.toArray(mxCell[]::new);
 		mxCell[] circuitContainers = Arrays.stream(mxGraphModel.filterCells(viewChildren, containerFilter))
 				.toArray(mxCell[]::new);
-		mxCell[] proteins = Arrays.stream(mxGraphModel.filterCells(viewChildren, proteinFilter)).toArray(mxCell[]::new);
+		mxCell[] molecularSpecies = Arrays.stream(mxGraphModel.filterCells(viewChildren, molecularSpeciesFilter)).toArray(mxCell[]::new);
 		mxCell[] textBoxes = Arrays.stream(mxGraphModel.filterCells(viewChildren, textBoxFilter))
 				.toArray(mxCell[]::new);
 
@@ -303,40 +297,40 @@ public class MxToSBOL extends Converter {
 			attachTextBoxAnnotation(model, viewCell, modDef.getIdentity());
 		}
 		
-		// proteins
-		for (mxCell protein : proteins) {
-			// proteins also have glyphInfos
-			GlyphInfo proteinInfo = (GlyphInfo) infoDict.get(protein.getValue());
-			if (proteinInfo.getUriPrefix() == null)
-			proteinInfo.setUriPrefix(URI_PREFIX);
-			FunctionalComponent proteinFuncComp = null;
+		// molecular species (proteins, small molecules, complexes, etc.)
+		for (mxCell molSpeciesCell : molecularSpecies) {
+			GlyphInfo molSpeciesInfo = (GlyphInfo) infoDict.get(molSpeciesCell.getValue());
+			if (molSpeciesInfo.getUriPrefix() == null)
+			molSpeciesInfo.setUriPrefix(URI_PREFIX);
+			FunctionalComponent molSpeciesFuncComp = null;
 			if (!layoutOnly) {
-				ComponentDefinition proteinCD = document.getComponentDefinition(new URI((String) protein.getValue()));
-				if (proteinCD == null) {
-					proteinCD = document.createComponentDefinition(proteinInfo.getUriPrefix(),
-					proteinInfo.getDisplayID(), proteinInfo.getVersion(),
-					SBOLData.types.getValue(proteinInfo.getPartType()));
-					proteinCD.setDescription(proteinInfo.getDescription());
-					proteinCD.setName(proteinInfo.getName());
-					proteinCD.addRole(SystemsBiologyOntology.INHIBITOR); // TODO determine from interaction
+				ComponentDefinition molSpeciesCD = document.getComponentDefinition(new URI((String) molSpeciesCell.getValue()));
+				if (molSpeciesCD == null) {
+					molSpeciesCD = document.createComponentDefinition(molSpeciesInfo.getUriPrefix(),
+					molSpeciesInfo.getDisplayID(), molSpeciesInfo.getVersion(),
+					SBOLData.types.getValue(molSpeciesInfo.getPartType()));
+					molSpeciesCD.setDescription(molSpeciesInfo.getDescription());
+					molSpeciesCD.setName(molSpeciesInfo.getName());
+					molSpeciesCD.addRole(SystemsBiologyOntology.INHIBITOR); // TODO determine from interaction
+					writeSimulationAnnotations(molSpeciesCD, molSpeciesInfo.getSimulationData(), molSpeciesCD.getDisplayId());
 				}
-				proteinFuncComp = modDef.createFunctionalComponent(proteinCD.getDisplayId() + "_" + protein.getId(),
-				AccessType.PUBLIC, proteinCD.getIdentity(), DirectionType.INOUT);
+				molSpeciesFuncComp = modDef.createFunctionalComponent(molSpeciesCD.getDisplayId() + "_" + molSpeciesCell.getId(),
+				AccessType.PUBLIC, molSpeciesCD.getIdentity(), DirectionType.INOUT);
 			} else {
 				// find the correct functionalComponent from the set of functional components
 				Set<FunctionalComponent> funcComps = modDef.getFunctionalComponents();
 				for (FunctionalComponent funcComp : funcComps) {
-					if (funcComp.getDefinitionIdentity().toString().equals((String) protein.getValue())) {
-						proteinFuncComp = funcComp;
+					if (funcComp.getDefinitionIdentity().toString().equals((String) molSpeciesCell.getValue())) {
+						molSpeciesFuncComp = funcComp;
 						break;
 					}
 				}
 			}
 			// the layout information in the component definition
-			if(proteinFuncComp == null){
+			if(molSpeciesFuncComp == null){
 				throw new NullPointerException("Cannot upload an edited import, it is not owned by you! Create a copy or make a new design.");
 			}
-			layoutHelper.addGraphicalNode(modDef.getIdentity(), proteinFuncComp.getDisplayId(), protein);
+			layoutHelper.addGraphicalNode(modDef.getIdentity(), molSpeciesFuncComp.getDisplayId(), molSpeciesCell);
 		}
 
 		// component definitions (should already have been created, just need to link
@@ -453,6 +447,9 @@ public class MxToSBOL extends Converter {
 //				compDef.addWasGeneratedBy(URI.create(generatedBy));
 //			}
 //		}
+
+		// persist simulation data as annotation
+		writeSimulationAnnotations(compDef, glyphInfo.getSimulationData(), compDef.getDisplayId());
 	}
 
 	private void createCombinatorial(SBOLDocument document, mxGraph graph, mxGraphModel model,
@@ -563,6 +560,9 @@ public class MxToSBOL extends Converter {
 			if (layoutOnly) {
 				return;
 			}
+
+			// persist interaction simulation data
+			writeSimulationAnnotations(interaction, intInfo.getSimulationData(), interaction.getDisplayId());
 
 			// populate sources and targets
 			if (interactionCell.getStyle().contains(STYLE_INTERACTION_NODE)) {
@@ -996,6 +996,31 @@ public class MxToSBOL extends Converter {
 
 		}
 		return sourceFC;
+	}
+
+	private void writeEvents(SBOLDocument document, mxGraph graph) throws SBOLValidationException {
+		if (eventDict == null || eventDict.isEmpty()) return;
+		for (EventInfo event : eventDict.values()) {
+			GenericTopLevel eventTL = document.createGenericTopLevel(
+					event.getUriPrefix(), event.getDisplayID(), "1", createQName("Event"));
+
+			// Write simulation data as nested annotation (same pattern as glyphs/interactions)
+			writeSimulationAnnotations(eventTL, event.getSimulationData(),
+					eventTL.getDisplayId());
+
+			// Save event cell position/geometry as flat annotations
+			mxCell eventCell = (mxCell) ((mxGraphModel) graph.getModel()).getCell(event.getFullURI());
+			if (eventCell != null && eventCell.getGeometry() != null) {
+				eventTL.createAnnotation(createQName("x"),
+						String.valueOf(eventCell.getGeometry().getX()));
+				eventTL.createAnnotation(createQName("y"),
+						String.valueOf(eventCell.getGeometry().getY()));
+				eventTL.createAnnotation(createQName("width"),
+						String.valueOf(eventCell.getGeometry().getWidth()));
+				eventTL.createAnnotation(createQName("height"),
+						String.valueOf(eventCell.getGeometry().getHeight()));
+			}
+		}
 	}
 
     /*

--- a/SBOLCanvasBackend/src/utils/SBOLData.java
+++ b/SBOLCanvasBackend/src/utils/SBOLData.java
@@ -18,6 +18,34 @@ import org.synbiohub.frontend.WebOfRegistriesData;
 
 public class SBOLData {
 
+	// Simulation parameter name constants. Used by SBOLData and MxToSBML
+	// Frontend model-editor component uses these same string values.
+	// If a frontend key doesn't match, getParam() silently falls through to defaults.
+	public static final String PARAM_KD = "kd";
+	public static final String PARAM_KC_F = "Kc_f";
+	public static final String PARAM_KC_R = "Kc_r";
+	public static final String PARAM_NC = "nc";
+	public static final String PARAM_NG = "ng";
+	public static final String PARAM_NP = "np";
+	public static final String PARAM_KO = "ko";
+	public static final String PARAM_KB = "kb";
+	public static final String PARAM_KA = "ka";
+	public static final String PARAM_KO_F = "Ko_f";
+	public static final String PARAM_KO_R = "Ko_r";
+	public static final String PARAM_KAO_F = "Kao_f";
+	public static final String PARAM_KAO_R = "Kao_r";
+	public static final String PARAM_NR = "nr";
+	public static final String PARAM_KR_F = "Kr_f";
+	public static final String PARAM_KR_R = "Kr_r";
+	public static final String PARAM_KA_F = "Ka_f";
+	public static final String PARAM_KA_R = "Ka_r";
+
+	// Event parameter name constants
+	public static final String PARAM_EVENT_NAME = "name";
+	public static final String PARAM_EVENT_TARGET_SPECIES = "targetSpecies";
+	public static final String PARAM_EVENT_DELAY = "delay";
+	public static final String PARAM_EVENT_ASSIGNMENT_VALUE = "assignmentValue";
+
 	private static SequenceOntology so;
 	private static SystemsBiologyOntology sbo;
 	
@@ -162,47 +190,47 @@ public class SBOLData {
 
 		// Degradation (SBO:0000179)
 		LinkedHashMap<String, Object> degradationParams = new LinkedHashMap<>();
-		degradationParams.put("kd", 0.0075); // Default degradation rate
+		degradationParams.put(PARAM_KD, 0.0075); // Default degradation rate
 		simulationConfig.put(interactions.getKey(SystemsBiologyOntology.DEGRADATION), degradationParams);
 
 		// Complex Formation (SBO:0000177)
 		// Kc_f/Kc_r on node, nc per-reactant on arrows to node
 		// Kc (complex formation) = Kc_f / Kc_r
 		LinkedHashMap<String, Object> complexParams = new LinkedHashMap<>();
-		complexParams.put("Kc_f", 0.05); // Forward complex formation rate
-		complexParams.put("Kc_r", 1.0); // Reverse complex formation rate
-		complexParams.put("nc", 2.0); // Stoichiometry of binding
+		complexParams.put(PARAM_KC_F, 0.05); // Forward complex formation rate
+		complexParams.put(PARAM_KC_R, 1.0); // Reverse complex formation rate
+		complexParams.put(PARAM_NC, 2.0); // Stoichiometry of binding
 		simulationConfig.put(interactions.getKey(SystemsBiologyOntology.BIOCHEMICAL_REACTION), complexParams);
 		simulationConfig.put(interactions.getKey(SystemsBiologyOntology.NON_COVALENT_BINDING), complexParams);
 
 		// Genetic Production (SBO:0000589) - Parameters are on the Promoter
 		LinkedHashMap<String, Object> promoterParams = new LinkedHashMap<>();
-		promoterParams.put("ng", 2.0); // Initial promoter count
-		promoterParams.put("np", 10.0); // Stoichiometry of production
-		promoterParams.put("ko", 0.05); // Open complex production rate
-		promoterParams.put("kb", 0.0001); // Basal production rate
-		promoterParams.put("ka", 0.25); // Activated production rate
-		promoterParams.put("Ko_f", 0.033); // Forward RNAP binding rate (Ko = Ko_f/Ko_r)
-		promoterParams.put("Ko_r", 1.0); // Reverse RNAP binding rate
-		promoterParams.put("Kao_f", 1.0); // Forward activated RNAP binding rate (Kao = Kao_f/Kao_r)
-		promoterParams.put("Kao_r", 1.0); // Reverse activated RNAP binding rate
-		promoterParams.put("nr", 30.0); // Initial RNAP count
+		promoterParams.put(PARAM_NG, 2.0); // Initial promoter count
+		promoterParams.put(PARAM_NP, 10.0); // Stoichiometry of production
+		promoterParams.put(PARAM_KO, 0.05); // Open complex production rate
+		promoterParams.put(PARAM_KB, 0.0001); // Basal production rate
+		promoterParams.put(PARAM_KA, 0.25); // Activated production rate
+		promoterParams.put(PARAM_KO_F, 0.033); // Forward RNAP binding rate (Ko = Ko_f/Ko_r)
+		promoterParams.put(PARAM_KO_R, 1.0); // Reverse RNAP binding rate
+		promoterParams.put(PARAM_KAO_F, 1.0); // Forward activated RNAP binding rate (Kao = Kao_f/Kao_r)
+		promoterParams.put(PARAM_KAO_R, 1.0); // Reverse activated RNAP binding rate
+		promoterParams.put(PARAM_NR, 30.0); // Initial RNAP count
 		simulationConfig.put(roles.getKey(SequenceOntology.PROMOTER), promoterParams);
 
 		// Inhibition (SBO:0000169)
 		// Kr (repression binding) = Kr_f / Kr_r
 		LinkedHashMap<String, Object> inhibitionParams = new LinkedHashMap<>();
-		inhibitionParams.put("Kr_f", 0.5); // Forward repression binding rate
-		inhibitionParams.put("Kr_r", 1.0); // Reverse repression binding rate
-		inhibitionParams.put("nc", 2.0); // Stoichiometry of binding
+		inhibitionParams.put(PARAM_KR_F, 0.5); // Forward repression binding rate
+		inhibitionParams.put(PARAM_KR_R, 1.0); // Reverse repression binding rate
+		inhibitionParams.put(PARAM_NC, 2.0); // Stoichiometry of binding
 		simulationConfig.put(interactions.getKey(SystemsBiologyOntology.INHIBITION), inhibitionParams);
 
 		// Stimulation (SBO:0000170)
 		// Ka (activation binding) = Ka_f / Ka_r
 		LinkedHashMap<String, Object> stimulationParams = new LinkedHashMap<>();
-		stimulationParams.put("Ka_f", 0.0033); // Forward activation binding rate
-		stimulationParams.put("Ka_r", 1.0); // Reverse activation binding rate
-		stimulationParams.put("nc", 2.0); // Stoichiometry of binding
+		stimulationParams.put(PARAM_KA_F, 0.0033); // Forward activation binding rate
+		stimulationParams.put(PARAM_KA_R, 1.0); // Reverse activation binding rate
+		stimulationParams.put(PARAM_NC, 2.0); // Stoichiometry of binding
 		simulationConfig.put(interactions.getKey(SystemsBiologyOntology.STIMULATION), stimulationParams);
 
 	}

--- a/SBOLCanvasBackend/src/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/utils/SBOLToMx.java
@@ -31,6 +31,7 @@ import org.sbolstandard.core2.Component;
 import org.sbolstandard.core2.ComponentDefinition;
 import org.sbolstandard.core2.ComponentInstance;
 import org.sbolstandard.core2.FunctionalComponent;
+import org.sbolstandard.core2.GenericTopLevel;
 import org.sbolstandard.core2.Identified;
 import org.sbolstandard.core2.Interaction;
 import org.sbolstandard.core2.Location;
@@ -59,6 +60,7 @@ import com.mxgraph.view.mxGraph;
 
 import data.CanvasAnnotation;
 import data.CombinatorialInfo;
+import data.EventInfo;
 import data.Info;
 import data.GlyphInfo;
 import data.IdentifiedInfo;
@@ -72,9 +74,7 @@ public class SBOLToMx extends Converter {
 	HashMap<FunctionalComponent, ComponentInstance> mappings;
 
 	public SBOLToMx() {
-		infoDict = new Hashtable<String, Info>();
-		combinatorialDict = new Hashtable<String, CombinatorialInfo>();
-		interactionDict = new Hashtable<String, InteractionInfo>();
+		super();
 		compToCell = new HashMap<ComponentInstance, mxCell>();
 		mappings = new HashMap<FunctionalComponent, ComponentInstance>();
 	}
@@ -108,6 +108,8 @@ public class SBOLToMx extends Converter {
 		dataContainer.add(INFO_DICT_INDEX, infoDict);
 		dataContainer.add(COMBINATORIAL_DICT_INDEX, combinatorialDict);
 		dataContainer.add(INTERACTION_DICT_INDEX, interactionDict);
+		eventDict = new Hashtable<String, EventInfo>();
+		dataContainer.add(EVENT_DICT_INDEX, eventDict);
 		cell0.setValue(dataContainer);
 
 		layoutHelper = new LayoutHelper(document, graph);
@@ -148,6 +150,51 @@ public class SBOLToMx extends Converter {
 			for (CombinatorialDerivation derivation : derivations) {
 				combinatorialDict.put(derivation.getIdentity().toString(),
 						genCombinatorialInfo(graph, model, derivation));
+			}
+		}
+
+		// read events from GenericTopLevel objects and create event cells
+		// Event parent: uses the first module view cell found under cell1.
+		// Limitation: multi-module designs will attach all events to the first module.
+		// This matches the frontend behavior (events go to graph.getDefaultParent()).
+		mxCell cell1 = (mxCell) model.getCell("1");
+		mxCell eventParent = null;
+		for (int i = 0; i < cell1.getChildCount(); i++) {
+			mxCell child = (mxCell) cell1.getChildAt(i);
+			if (STYLE_MODULE_VIEW.equals(child.getStyle())) {
+				eventParent = child;
+				break;
+			}
+		}
+		for (GenericTopLevel gtl : document.getGenericTopLevels()) {
+			if (gtl.getRDFType().equals(createQName("Event"))) {
+				try {
+					EventInfo event = new EventInfo();
+					event.setDisplayID(gtl.getDisplayId());
+					event.setUriPrefix(getURIPrefix(gtl));
+
+					// Read simulation data from nested annotation
+					event.setSimulationData(readSimulationAnnotations(gtl));
+
+					// Read geometry from flat annotations
+					double x = 0, y = 0, width = 96, height = 40;
+					for (Annotation ann : gtl.getAnnotations()) {
+						switch (ann.getQName().getLocalPart()) {
+							case "x": x = Double.parseDouble(ann.getStringValue()); break;
+							case "y": y = Double.parseDouble(ann.getStringValue()); break;
+							case "width": width = Double.parseDouble(ann.getStringValue()); break;
+							case "height": height = Double.parseDouble(ann.getStringValue()); break;
+						}
+					}
+
+					eventDict.put(event.getFullURI(), event);
+					if (eventParent != null) {
+						graph.insertVertex(eventParent, event.getFullURI(), event.getFullURI(),
+								x, y, width, height, STYLE_EVENT);
+					}
+				} catch (Exception e) {
+					System.err.println("Skipping invalid event '" + gtl.getDisplayId() + "': " + e.toString());
+				}
 			}
 		}
 
@@ -601,7 +648,15 @@ public class SBOLToMx extends Converter {
 			glyphInfo.setGeneratedBys(generatedBys);
 		}
 
-		glyphInfo.setAnnotations(convertSBOLAnnotations(glyphCD.getAnnotations()));
+		// filter out simulationData annotation before converting to canvas annotations
+		List<Annotation> nonSimAnnotations = new ArrayList<Annotation>();
+		for (Annotation ann : glyphCD.getAnnotations()) {
+			if (!ann.getQName().getLocalPart().equals("simulationData")) {
+				nonSimAnnotations.add(ann);
+			}
+		}
+		glyphInfo.setAnnotations(convertSBOLAnnotations(nonSimAnnotations));
+		glyphInfo.setSimulationData(readSimulationAnnotations(glyphCD));
 		return glyphInfo;
 	}
 
@@ -610,6 +665,7 @@ public class SBOLToMx extends Converter {
 		info.setDisplayID(interaction.getDisplayId());
 		info.setInteractionType(SBOLData.interactions.getKey(interaction.getTypes().iterator().next()));
 		info.setUriPrefix(getURIPrefix(interaction));
+		info.setSimulationData(readSimulationAnnotations(interaction));
 		return info;
 	}
 
@@ -773,13 +829,5 @@ public class SBOLToMx extends Converter {
 		}
 		return identity.substring(0, lastIndex - 1);
 	}
-
-//	private Object decodeMxGraphObject(String xml) throws SAXException, IOException, ParserConfigurationException {
-//		Document stringDoc = mxXmlUtils.parseXml(xml);
-//		mxCodec codec = new mxCodec(stringDoc);
-//		Node node = stringDoc.getDocumentElement();
-//		Object obj = codec.decode(node);
-//		return obj;
-//	}
 
 }

--- a/SBOLCanvasFrontend/src/app/eventInfo.ts
+++ b/SBOLCanvasFrontend/src/app/eventInfo.ts
@@ -2,10 +2,7 @@ import { Info } from './info';
 import { environment } from 'src/environments/environment';
 
 export class EventInfo extends Info {
-    name: string;
-    targetSpecies: string;
-    delay: number = 0; // Defaults to 0
-    assignmentValue: number = 0; // Defaults to 0
+    simulationData = {};
 
     constructor() {
         super();
@@ -20,20 +17,14 @@ export class EventInfo extends Info {
         const copy: EventInfo = new EventInfo();
         copy.uriPrefix = this.uriPrefix;
         copy.displayID = this.displayID;
-        copy.name = this.name;
-        copy.delay = this.delay;
-        copy.targetSpecies = this.targetSpecies;
-        copy.assignmentValue = this.assignmentValue;
+        copy.simulationData = this.simulationData ? { ...this.simulationData } : {};
         return copy;
     }
 
     copyDataFrom(other: EventInfo) {
         this.uriPrefix = other.uriPrefix;
         this.displayID = other.displayID;
-        this.name = other.name;
-        this.delay = other.delay;
-        this.targetSpecies = other.targetSpecies;
-        this.assignmentValue = other.assignmentValue;
+        this.simulationData = other.simulationData ? { ...other.simulationData } : {};
     }
 
     encode(enc: any) {
@@ -42,15 +33,17 @@ export class EventInfo extends Info {
             node.setAttribute("uriPrefix", this.uriPrefix);
         if (this.displayID)
             node.setAttribute("displayID", this.displayID);
-        if (this.name)
-            node.setAttribute("name", this.name);
-        if (this.delay)
-            node.setAttribute("delay", this.delay.toString());
-        if (this.targetSpecies)
-            node.setAttribute("targetSpecies", this.targetSpecies);
-        if (this.assignmentValue)
-            node.setAttribute("assignmentValue", this.assignmentValue.toString());
-
+        if (this.simulationData) {
+            let simulationDataNode = enc.document.createElement("Array");
+            simulationDataNode.setAttribute("as", "simulationData");
+            for (let key in this.simulationData) {
+                let dataNode = enc.document.createElement("add");
+                dataNode.setAttribute("value", this.simulationData[key]);
+                dataNode.setAttribute("as", key);
+                simulationDataNode.appendChild(dataNode);
+            }
+            node.appendChild(simulationDataNode);
+        }
         return node;
     }
 }

--- a/SBOLCanvasFrontend/src/app/files.service.ts
+++ b/SBOLCanvasFrontend/src/app/files.service.ts
@@ -85,10 +85,13 @@ export class FilesService {
         default:
           formatExtension = ".xml"; break;
       }
-      this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe(result => {
-        var file = new File([result], filename + formatExtension);
-        FileSaver.saveAs(file);
-        observer.next();
+      this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe({
+        next: result => {
+          var file = new File([result], filename + formatExtension);
+          FileSaver.saveAs(file);
+          observer.next();
+        },
+        error: err => observer.error(err)
       });
     });
   }

--- a/SBOLCanvasFrontend/src/app/glyph-menu/glyph-menu.component.html
+++ b/SBOLCanvasFrontend/src/app/glyph-menu/glyph-menu.component.html
@@ -95,7 +95,8 @@
         <!-------------------------------------    Utils panel   --------------------------------------->
         <mat-expansion-panel class="glyphMenuSection" [expanded]="true" *ngIf="
                     (!componentDefinitionMode && stringMatches('backbone dna strand circuit', searchPhrase))
-                    || stringMatches('textbox text box', searchPhrase)">
+                    || stringMatches('textbox text box', searchPhrase)
+                    || stringMatches('event simulation time', searchPhrase)">
       <mat-expansion-panel-header>
         <mat-panel-title>
           Util

--- a/SBOLCanvasFrontend/src/app/graph-helpers.ts
+++ b/SBOLCanvasFrontend/src/app/graph-helpers.ts
@@ -2173,8 +2173,8 @@ export class GraphHelpers extends GraphBase {
                 let info = <EventInfo>graphService.getFromEventDict(cell.value)
                 if (!info) {
                     return cell.value
-                } else if (info.name != null && info.name != '') {
-                    return info.name
+                } else if (info.simulationData && info.simulationData['name'] != null && info.simulationData['name'] != '') {
+                    return info.simulationData['name']
                 } else {
                     return info.displayID
                 }

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -1526,7 +1526,7 @@ export class GraphService extends GraphHelpers {
             eventInfo.displayID = 'Event_' + Math.random().toString(36).substring(7)
             this.addToEventDict(eventInfo)
 
-            const eventCell = this.graph.insertVertex(this.graph.getDefaultParent(), null, eventInfo.getFullURI(), x, y, GraphBase.defaultEventWidth, GraphBase.defaultEventHeight, GraphBase.STYLE_EVENT)
+            const eventCell = this.graph.insertVertex(this.graph.getDefaultParent(), eventInfo.getFullURI(), eventInfo.getFullURI(), x, y, GraphBase.defaultEventWidth, GraphBase.defaultEventHeight, GraphBase.STYLE_EVENT)
             eventCell.setConnectable(false)
 
             this.graph.clearSelection()

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.html
@@ -89,24 +89,28 @@
     <h4>Event</h4>
     <mat-form-field floatLabel="always">
       <mat-label>Name</mat-label>
-      <input matInput id="name" value="{{eventInfo.name}}" (change)="inputChange($event)"
+      <input matInput id="name" value="{{eventInfo.simulationData['name'] || ''}}" (change)="inputChange($event)"
         matTooltip="Event identifier used in SBML (e.g., 'IPTG_High', 'aTc_Low')">
     </mat-form-field>
 
     <mat-form-field floatLabel="always">
       <mat-label>Delay (time)</mat-label>
-      <input matInput id="delay" type="number" value="{{eventInfo.delay}}" (change)="inputChange($event)">
+      <input matInput id="delay" type="number"
+        value="{{eventInfo.simulationData['delay'] !== undefined ? eventInfo.simulationData['delay'] : 0}}"
+        (change)="inputChange($event)">
       <mat-error *ngIf="validationErrors['delay']">{{validationErrors['delay']}}</mat-error>
     </mat-form-field>
 
     <mat-form-field floatLabel="always">
       <mat-label>Target Species</mat-label>
-      <input matInput id="targetSpecies" value="{{eventInfo.targetSpecies}}" (change)="inputChange($event)">
+      <input matInput id="targetSpecies" value="{{eventInfo.simulationData['targetSpecies'] || ''}}"
+        (change)="inputChange($event)">
     </mat-form-field>
 
     <mat-form-field floatLabel="always">
       <mat-label>Assignment Value</mat-label>
-      <input matInput id="assignmentValue" type="number" value="{{eventInfo.assignmentValue}}"
+      <input matInput id="assignmentValue" type="number"
+        value="{{eventInfo.simulationData['assignmentValue'] !== undefined ? eventInfo.simulationData['assignmentValue'] : 0}}"
         (change)="inputChange($event)">
       <mat-error *ngIf="validationErrors['assignmentValue']">{{validationErrors['assignmentValue']}}</mat-error>
     </mat-form-field>

--- a/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.ts
+++ b/SBOLCanvasFrontend/src/app/model-editor/model-editor.component.ts
@@ -140,6 +140,9 @@ export class ModelEditorComponent implements OnInit {
   eventInfoUpdated(eventInfo: EventInfo) {
     this.eventInfo = eventInfo;
     this.validationErrors = {};
+    if (eventInfo != null) {
+      if (!this.eventInfo.simulationData) this.eventInfo.simulationData = {};
+    }
     this.changeDetector.detectChanges();
   }
 
@@ -199,13 +202,8 @@ export class ModelEditorComponent implements OnInit {
     delete this.validationErrors[id];
 
     if (this.eventInfo) {
-      // Direct properties (Events)
-      switch (id) {
-        case 'name': this.eventInfo.name = value; break;
-        case 'delay': this.eventInfo.delay = value; break;
-        case 'targetSpecies': this.eventInfo.targetSpecies = value; break;
-        case 'assignmentValue': this.eventInfo.assignmentValue = value; break;
-      }
+      if (!this.eventInfo.simulationData) this.eventInfo.simulationData = {};
+      this.eventInfo.simulationData[id] = value;
       this.graphService.setSelectedCellInfo(this.eventInfo);
     } else if (this.glyphInfo) {
       // Simulation data properties (glyphs)


### PR DESCRIPTION
Rates, stoichiometries, event triggers, and event canvas layout persists through SBOL exports and imports

**Backend**
- Persist simulation data as SBOL annotations on ComponentDefinitions, Interactions, and events (GenericTopLevels)
- Refactor EventInfo to use `simulationData` Hashtable, matching GlyphInfo/InteractionInfo pattern
- Extract shared read/write annotation helpers into Converter, consolidate duplicate dictionary-loading
- Resolve display names to SBML species IDs for event targets and use `SBOLData` constants
- Add null guards across converters

**Frontend**
- Refactor eventInfo.ts to match backend `simulationData` pattern
- Register custom mxCodec decoders for simulation data deserialization
- Update model-editor simulation fields
- Fix silent export errors in files.service