### PR TITLE
Add SBML auto-export and fix silent HTTP errors

### DIFF
--- a/SBOLCanvasFrontend/src/app/collection-creation/collection-creation.component.ts
+++ b/SBOLCanvasFrontend/src/app/collection-creation/collection-creation.component.ts
@@ -42,9 +42,14 @@ export class CollectionCreationComponent implements OnInit {
   onCreateClick() {
     this.working = true;
     const registryAPI = this.loginService.getRegistryAPI(this.registry);
-    this.filesService.createCollection(registryAPI, this.loginService.users[registryAPI], this.id, this.version, this.name, this.description, this.citations, this.overwrite, this.loginService.getRegistryPrefix(this.registry)).subscribe(_ => {
-      this.dialogRef.close(true);
-      this.working = false;
+    this.filesService.createCollection(registryAPI, this.loginService.users[registryAPI], this.id, this.version, this.name, this.description, this.citations, this.overwrite, this.loginService.getRegistryPrefix(this.registry)).subscribe({
+      next: _ => {
+        this.dialogRef.close(true);
+        this.working = false;
+      },
+      error: _ => {
+        this.working = false;
+      }
     });
   }
 

--- a/SBOLCanvasFrontend/src/app/export-design/export-design.component.ts
+++ b/SBOLCanvasFrontend/src/app/export-design/export-design.component.ts
@@ -66,7 +66,6 @@ export class ExportDesignComponent implements OnInit {
 
   finishCheck():boolean {
     return this.filename != null && this.filename.length > 0;
-    return false;
   }
 
 }

--- a/SBOLCanvasFrontend/src/app/files.service.ts
+++ b/SBOLCanvasFrontend/src/app/files.service.ts
@@ -55,9 +55,12 @@ export class FilesService {
         const reader = new FileReader();
 
         reader.onload = (e: any) => {
-          this.convertToMxGraph(String(reader.result)).subscribe(result => {
-            graphService.setGraphToXML(result);
-            observer.next();
+          this.convertToMxGraph(String(reader.result)).subscribe({
+            next: result => {
+              graphService.setGraphToXML(result);
+              observer.next();
+            },
+            error: err => observer.error(err)
           });
         };
 
@@ -137,10 +140,13 @@ export class FilesService {
         case "CSV":
           formatExtension = ".csv"; break;
       }
-      this.http.post(this.enumerateDesignURL, contents, {headers: headers, responseType: 'text', params: params }).subscribe(result => {
-        var file = new File([result], filename + formatExtension);
-        FileSaver.saveAs(file);
-        observer.next();
+      this.http.post(this.enumerateDesignURL, contents, {headers: headers, responseType: 'text', params: params }).subscribe({
+        next: result => {
+          var file = new File([result], filename + formatExtension);
+          FileSaver.saveAs(file);
+          observer.next();
+        },
+        error: err => observer.error(err)
       });
     });
   }
@@ -250,8 +256,11 @@ export class FilesService {
           if(uriPrefix)
             params = params.append("uriPrefix", uriPrefix);
           params = params.append("uri", collection);
-          this.http.post(this.importToCollectionURL, String(reader.result), { responseType: 'text', headers: headers, params: params }).subscribe(_ => {
-            observer.next();
+          this.http.post(this.importToCollectionURL, String(reader.result), { responseType: 'text', headers: headers, params: params }).subscribe({
+            next: _ => {
+              observer.next();
+            },
+            error: err => observer.error(err)
           });
         };
 
@@ -276,8 +285,11 @@ export class FilesService {
       params = params.append("description", description);
       params = params.append("citations", citations ? citations : '');
       params = params.append("overwrite", overwrite ? "true" : "false");
-      return this.http.post(this.createCollectionURL, "", {responseType: 'text', headers: headers, params: params }).subscribe(result => {
-        observer.next();
+      this.http.post(this.createCollectionURL, "", {responseType: 'text', headers: headers, params: params }).subscribe({
+        next: result => {
+          observer.next();
+        },
+        error: err => observer.error(err)
       });
     });
   }

--- a/SBOLCanvasFrontend/src/app/files.service.ts
+++ b/SBOLCanvasFrontend/src/app/files.service.ts
@@ -103,8 +103,14 @@ export class FilesService {
       let params = new HttpParams();
       params = params.append("format", format);
 
-      this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe(result => {
-        observer.next(result);
+      this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe({
+        next: result => {
+          observer.next(result);
+          observer.complete();
+        },
+        error: err => {
+          observer.error(err);
+        }
       });
     });
   }

--- a/SBOLCanvasFrontend/src/app/files.service.ts
+++ b/SBOLCanvasFrontend/src/app/files.service.ts
@@ -59,6 +59,7 @@ export class FilesService {
             next: result => {
               graphService.setGraphToXML(result);
               observer.next();
+              observer.complete();
             },
             error: err => observer.error(err)
           });
@@ -67,6 +68,7 @@ export class FilesService {
         reader.readAsText(file);
       } else {
         observer.next();
+        observer.complete();
       }
     });
   }
@@ -88,11 +90,12 @@ export class FilesService {
         default:
           formatExtension = ".xml"; break;
       }
-      this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe({
+      return this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe({
         next: result => {
           var file = new File([result], filename + formatExtension);
           FileSaver.saveAs(file);
           observer.next();
+          observer.complete();
         },
         error: err => observer.error(err)
       });
@@ -106,7 +109,7 @@ export class FilesService {
       let params = new HttpParams();
       params = params.append("format", format);
 
-      this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe({
+      return this.http.post(this.exportDesignURL, contents, { headers: headers, responseType: 'text', params: params }).subscribe({
         next: result => {
           observer.next(result);
           observer.complete();
@@ -140,11 +143,12 @@ export class FilesService {
         case "CSV":
           formatExtension = ".csv"; break;
       }
-      this.http.post(this.enumerateDesignURL, contents, {headers: headers, responseType: 'text', params: params }).subscribe({
+      return this.http.post(this.enumerateDesignURL, contents, {headers: headers, responseType: 'text', params: params }).subscribe({
         next: result => {
           var file = new File([result], filename + formatExtension);
           FileSaver.saveAs(file);
           observer.next();
+          observer.complete();
         },
         error: err => observer.error(err)
       });
@@ -259,6 +263,7 @@ export class FilesService {
           this.http.post(this.importToCollectionURL, String(reader.result), { responseType: 'text', headers: headers, params: params }).subscribe({
             next: _ => {
               observer.next();
+              observer.complete();
             },
             error: err => observer.error(err)
           });
@@ -267,6 +272,7 @@ export class FilesService {
         reader.readAsText(file);
       } else {
         observer.next();
+        observer.complete();
       }
     });
   }
@@ -285,9 +291,10 @@ export class FilesService {
       params = params.append("description", description);
       params = params.append("citations", citations ? citations : '');
       params = params.append("overwrite", overwrite ? "true" : "false");
-      this.http.post(this.createCollectionURL, "", {responseType: 'text', headers: headers, params: params }).subscribe({
-        next: result => {
+      return this.http.post(this.createCollectionURL, "", {responseType: 'text', headers: headers, params: params }).subscribe({
+        next: _ => {
           observer.next();
+          observer.complete();
         },
         error: err => observer.error(err)
       });

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -25,7 +25,7 @@ import { EventInfo } from './eventInfo';
 import { EmbeddedService } from './embedded.service';
 import { FilesService } from './files.service';
 import { Observable } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
+import { debounceTime, share } from 'rxjs/operators';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @Injectable({
@@ -52,17 +52,41 @@ export class GraphService extends GraphHelpers {
 
         // send changes in mxgraph model to parent
         // doing this via an Observable so we can debounce
-        new Observable<any>(observer => {
+        const modelChange$ = new Observable<any>(observer => {
             this.graph.getModel().addListener(mx.mxEvent.CHANGE, mx.mxUtils.bind(this, () => {
                 observer.next(this.getGraphXML())
             }))
-        })
+        }).pipe(share())
+
+        // SBOL auto-export pipeline (100ms debounce)
+        modelChange$
         .pipe(debounceTime(100))
         .subscribe(graphXml => {
             if (embeddedService.isAppEmbedded()) {
-                console.debug('[GraphService] Model changed. Sending to parent.')
+                console.debug('[GraphService] Model changed. Sending SBOL to parent.')
                 fileService.exportDesignToString({}, 'SBOL2', graphXml).subscribe(sbol => {
                     embeddedService.postMessage({ sbol })
+                })
+            }
+        })
+
+        // SBML auto-export pipeline (2000ms debounce)
+        modelChange$
+        .pipe(debounceTime(2000))
+        .subscribe(graphXml => {
+            if (embeddedService.isAppEmbedded()) {
+                console.debug('[GraphService] Model changed. Sending SBML to parent.')
+                fileService.exportDesignToString({}, 'SBML', graphXml).subscribe({
+                    next: sbml => {
+                        embeddedService.postMessage({ sbml })
+                    },
+                    error: err => {
+                        console.error('[GraphService] SBML export failed:', err)
+                        const message = err.error || err.message || 'SBML export failed'
+                        embeddedService.postMessage({
+                            error: { type: 'sbml-export', message: message }
+                        })
+                    }
                 })
             }
         })

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -64,8 +64,17 @@ export class GraphService extends GraphHelpers {
         .subscribe(graphXml => {
             if (embeddedService.isAppEmbedded()) {
                 console.debug('[GraphService] Model changed. Sending SBOL to parent.')
-                fileService.exportDesignToString({}, 'SBOL2', graphXml).subscribe(sbol => {
-                    embeddedService.postMessage({ sbol })
+                fileService.exportDesignToString({}, 'SBOL2', graphXml).subscribe({
+                    next: sbol => {
+                        embeddedService.postMessage({ sbol })
+                    },
+                    error: err => {
+                        console.error('[GraphService] SBOL export failed:', err)
+                        const message = typeof err.error === 'string' ? err.error : err.message || 'SBOL export failed'
+                        embeddedService.postMessage({
+                            error: { type: 'sbol-export', message: message }
+                        })
+                    }
                 })
             }
         })
@@ -82,7 +91,7 @@ export class GraphService extends GraphHelpers {
                     },
                     error: err => {
                         console.error('[GraphService] SBML export failed:', err)
-                        const message = err.error || err.message || 'SBML export failed'
+                        const message = typeof err.error === 'string' ? err.error : err.message || 'SBML export failed'
                         embeddedService.postMessage({
                             error: { type: 'sbml-export', message: message }
                         })

--- a/SBOLCanvasFrontend/src/app/load-graph/load-graph.component.ts
+++ b/SBOLCanvasFrontend/src/app/load-graph/load-graph.component.ts
@@ -30,9 +30,14 @@ export class LoadGraphComponent implements OnInit {
 
   onOkClick(){
     this.working = true;
-    this.filesService.loadLocal(this.data.file, this.graphService).subscribe(_ => {
-      this.working = false;
-      this.dialogRef.close();
+    this.filesService.loadLocal(this.data.file, this.graphService).subscribe({
+      next: _ => {
+        this.working = false;
+        this.dialogRef.close();
+      },
+      error: _ => {
+        this.working = false;
+      }
     });
   }
 

--- a/SBOLCanvasFrontend/src/app/upload-graph/upload-graph.component.ts
+++ b/SBOLCanvasFrontend/src/app/upload-graph/upload-graph.component.ts
@@ -101,9 +101,14 @@ export class UploadGraphComponent implements OnInit {
 
   onImportClick(){
     this.working = true;
-    this.filesService.importSBOL(this.file, this.getRegistryAPI(), this.collection, this.loginService.users[this.getRegistryAPI()], this.getRegistryPrefix()).subscribe(result =>{
-      this.working = false;
-      this.dialogRef.close();
+    this.filesService.importSBOL(this.file, this.getRegistryAPI(), this.collection, this.loginService.users[this.getRegistryAPI()], this.getRegistryPrefix()).subscribe({
+      next: _ => {
+        this.working = false;
+        this.dialogRef.close();
+      },
+      error: _ => {
+        this.working = false;
+      }
     });
   }
 


### PR DESCRIPTION
SBOLCanvas only sent SBOL to the parent iframe. The parent also needs SBML for simulation, and HTTP errors in export calls were silently dropped.

- Add SBML export pipeline via `postMessage` (2000ms debounce, shares model-change Observable with SBOL)
- Send structured error messages to parent on export failure
- Fix 5 methods in `files.service.ts` that silently swallowed HTTP errors