### PR TITLE
Move export validation from backend errors to frontend warnings

### DIFF
--- a/SBOLCanvasBackend/src/utils/MxToSBML.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBML.java
@@ -458,7 +458,7 @@ public class MxToSBML extends Converter {
 	 * Builds the repression-only Hill equation formula.
 	 *
 	 * Parameters:
-	 * ko, ko_f, ko_r, nr, kr_f_<repId>, kr_r_<repId>, nc_<repId>
+	 * ko, ko_f, ko_r, nr, kr_<repId>_f, kr_<repId>_r, nc_<repId>_r
 	 * 
 	 * Formula:
 	 * (P * ko * (ko_f/ko_r) * nr) / (1 + (ko_f/ko_r) * nr + ((kr_f/kr_r) * R)^nc)
@@ -491,9 +491,9 @@ public class MxToSBML extends Converter {
 		double Kr_r = getParam(repSimData, SBOLData.PARAM_KR_R, SystemsBiologyOntology.INHIBITION, repContext);
 		double nc = getParam(repSimData, SBOLData.PARAM_NC, SystemsBiologyOntology.INHIBITION, repContext);
 
-		String p_Krf = "kr_f_" + repId;
-		String p_Krr = "kr_r_" + repId;
-		String p_nc = "nc_" + repId;
+		String p_Krf = "kr_" + repId + "_f";
+		String p_Krr = "kr_" + repId + "_r";
+		String p_nc = "nc_" + repId + "_r";
 		law.createLocalParameter(p_Krf).setValue(Kr_f);
 		law.createLocalParameter(p_Krr).setValue(Kr_r);
 		law.createLocalParameter(p_nc).setValue(nc);
@@ -518,7 +518,7 @@ public class MxToSBML extends Converter {
 	 * / (1 + (ko_f/ko_r) * nr + (kao_f/kao_r) * nr * ((ka_f/ka_r) * A)^nc)
 	 *
 	 * Parameters:
-	 * kb, ka, ko_f, ko_r, kao_f, kao_r, nr, ka_f_<actId>, ka_r_<actId>, nc_<actId>
+	 * kb, ka, ko_f, ko_r, kao_f, kao_r, nr, ka_<actId>_f, ka_<actId>_r, nc_<actId>_a
 	 */
 	private void buildActivationFormula(Reaction reaction, String promoterId, GlyphInfo promoterInfo,
 			mxCell activatorEdge) {
@@ -554,9 +554,9 @@ public class MxToSBML extends Converter {
 		double Ka_r = getParam(actSimData, SBOLData.PARAM_KA_R, SystemsBiologyOntology.STIMULATION, actContext);
 		double nc = getParam(actSimData, SBOLData.PARAM_NC, SystemsBiologyOntology.STIMULATION, actContext);
 
-		String p_Kaf = "ka_f_" + actId;
-		String p_Kar = "ka_r_" + actId;
-		String p_nc = "nc_" + actId;
+		String p_Kaf = "ka_" + actId + "_f";
+		String p_Kar = "ka_" + actId + "_r";
+		String p_nc = "nc_" + actId + "_a";
 		law.createLocalParameter(p_Kaf).setValue(Ka_f);
 		law.createLocalParameter(p_Kar).setValue(Ka_r);
 		law.createLocalParameter(p_nc).setValue(nc);

--- a/SBOLCanvasBackend/src/utils/MxToSBML.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBML.java
@@ -158,8 +158,6 @@ public class MxToSBML extends Converter {
 
 		SBMLDocument document = setupDocument(graphStream);
 
-		// Write to SBML document stream
-		// https://sbml.org/jsbml/files/doc/api/1.6.1/org/sbml/jsbml/SBMLWriter.html
 		org.sbml.jsbml.TidySBMLWriter.write(document, sbmlStream, "SBOLCanvas", "1.0", ' ', (short) 2);
 	}
 
@@ -228,10 +226,8 @@ public class MxToSBML extends Converter {
 					}
 				}
 
-				// TODO: For all IllegalArgumentExceptions, add user validation before export
-				if (promoterGlyph == null) {
-					throw new IllegalArgumentException("Backbone has no promoter glyph. Add a Promoter to the backbone for SBML export.");
-				}
+				if (promoterGlyph == null)
+					continue;
 
 				GlyphInfo promoterInfo = (GlyphInfo) infoDict.get(promoterGlyph.getValue());
 				String promoterName = promoterInfo.getName();
@@ -280,6 +276,8 @@ public class MxToSBML extends Converter {
 
 			for (mxCell glyph : speciesGlyphs) {
 				Species species = createSpecies(sbmlModel, glyph);
+				if (species == null)
+					continue;
 				glyphToSpeciesData.put((String) glyph.getValue(),
 						new SpeciesData(species, glyph.getGeometry()));
 			}
@@ -304,9 +302,8 @@ public class MxToSBML extends Converter {
 
 				if (cell.isEdge()) {
 					InteractionInfo info = (InteractionInfo) interactionDict.get(cell.getValue());
-					if (info == null) {
+					if (info == null)
 						continue;
-					}
 
 					String type = info.getInteractionType();
 					URI typeURI = SBOLData.interactions.getValue(type);
@@ -345,13 +342,11 @@ public class MxToSBML extends Converter {
 			double np = getParam(promoterInfo.getSimulationData(), SBOLData.PARAM_NP, SequenceOntology.PROMOTER, "promoter '" + promoterId + "'");
 			for (mxCell productionEdge : tuData.productionEdges) {
 				mxCell targetCell = (mxCell) productionEdge.getTarget();
-				if (targetCell == null) {
-					throw new IllegalArgumentException("Production edge has no target cell (disconnected edge)");
-				}
+				if (targetCell == null)
+					continue;
 				SpeciesData productData = glyphToSpeciesData.get((String) targetCell.getValue());
-				if (productData == null) {
-					throw new IllegalArgumentException("Product species not found for production edge");
-				}
+				if (productData == null)
+					continue;
 				SpeciesReference product = reaction.createProduct(productData.species);
 				product.setConstant(true);
 				product.setStoichiometry(np);
@@ -372,19 +367,17 @@ public class MxToSBML extends Converter {
 
 					if (typeURI != null && modifierCell != null) {
 						if (typeURI.equals(SBOLData.interactions.getValue("Inhibition"))) {
-							repressorEdge = inEdge;
 							SpeciesData modifierData = glyphToSpeciesData.get((String) modifierCell.getValue());
-							if (modifierData == null) {
-								throw new IllegalArgumentException("Repressor species not found for inhibition edge");
-							}
+							if (modifierData == null)
+								continue;
+							repressorEdge = inEdge;
 							ModifierSpeciesReference mod = reaction.createModifier(modifierData.species);
 							mod.setSBOTerm(20); // SBO:0000020 Inhibitor
 						} else if (typeURI.equals(SBOLData.interactions.getValue("Stimulation"))) {
-							activatorEdge = inEdge;
 							SpeciesData modifierData = glyphToSpeciesData.get((String) modifierCell.getValue());
-							if (modifierData == null) {
-								throw new IllegalArgumentException("Activator species not found for stimulation edge");
-							}
+							if (modifierData == null)
+								continue;
+							activatorEdge = inEdge;
 							ModifierSpeciesReference mod = reaction.createModifier(modifierData.species);
 							mod.setSBOTerm(459); // SBO:0000459 Stimulator
 						}
@@ -392,22 +385,15 @@ public class MxToSBML extends Converter {
 				}
 			}
 
-			if (repressorEdge != null && activatorEdge != null) {
-				throw new IllegalArgumentException(
-						"Mixed regulation (both activators and repressors) not supported for promoter: " + promoterId);
-			}
+			if (repressorEdge != null && activatorEdge != null)
+				continue;
 
-			// TODO: Unregulated promoters not supported
 			if (repressorEdge != null) {
 				buildRepressionFormula(reaction, promoterId, promoterInfo, repressorEdge);
 			} else if (activatorEdge != null) {
 				buildActivationFormula(reaction, promoterId, promoterInfo, activatorEdge);
 			} else {
-				String promoterName = promoterInfo.getName();
-				if (promoterName == null || promoterName.isEmpty()) {
-					promoterName = promoterInfo.getDisplayID();
-				}
-				throw new IllegalArgumentException("Promoter '" + promoterName + "' has no regulator.");
+				// TODO: Add constitutive (unregulated) promoter formula
 			}
 		}
 	}
@@ -428,9 +414,8 @@ public class MxToSBML extends Converter {
 
 				if (cell.isEdge()) {
 					InteractionInfo info = (InteractionInfo) interactionDict.get(cell.getValue());
-					if (info == null) {
+					if (info == null)
 						continue;
-					}
 
 					String type = info.getInteractionType();
 					URI typeURI = SBOLData.interactions.getValue(type);
@@ -496,9 +481,7 @@ public class MxToSBML extends Converter {
 
 		mxCell repCell = (mxCell) repressorEdge.getSource();
 		SpeciesData repData = glyphToSpeciesData.get((String) repCell.getValue());
-		if (repData == null) {
-			throw new IllegalArgumentException("Repressor species not found for edge");
-		}
+		if (repData == null) return;
 		String repId = repData.species.getId();
 
 		InteractionInfo repInfo = (InteractionInfo) interactionDict.get(repressorEdge.getValue());
@@ -523,7 +506,7 @@ public class MxToSBML extends Converter {
 		try {
 			law.setMath(new FormulaParser(new ByteArrayInputStream(formula.getBytes(StandardCharsets.UTF_8))).parse());
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to parse repression kinetic law: " + e.getMessage(), e);
+			System.err.println("Warning: repression formula parse failed for " + promoterId + ": " + e.getMessage());
 		}
 	}
 
@@ -561,9 +544,7 @@ public class MxToSBML extends Converter {
 
 		mxCell actCell = (mxCell) activatorEdge.getSource();
 		SpeciesData actData = glyphToSpeciesData.get((String) actCell.getValue());
-		if (actData == null) {
-			throw new IllegalArgumentException("Activator species not found for edge");
-		}
+		if (actData == null) return;
 		String actId = actData.species.getId();
 
 		InteractionInfo actInfo = (InteractionInfo) interactionDict.get(activatorEdge.getValue());
@@ -592,7 +573,7 @@ public class MxToSBML extends Converter {
 		try {
 			law.setMath(new FormulaParser(new ByteArrayInputStream(formula.getBytes(StandardCharsets.UTF_8))).parse());
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to parse activation kinetic law: " + e.getMessage(), e);
+			System.err.println("Warning: activation formula parse failed for " + promoterId + ": " + e.getMessage());
 		}
 	}
 
@@ -716,7 +697,7 @@ public class MxToSBML extends Converter {
 	 */
 	private void createVisualLayout(Model sbmlModel) {
 		if (glyphToSpeciesData.isEmpty()) {
-			return; // No species — layout bounds are uninitialized
+			return; // No species -- layout bounds are uninitialized
 		}
 
 		Layout layout = setupLayout(sbmlModel);
@@ -747,16 +728,14 @@ public class MxToSBML extends Converter {
 
 			String targetSpecies = getStringParam(simData, SBOLData.PARAM_EVENT_TARGET_SPECIES);
 			if (targetSpecies == null || targetSpecies.isEmpty()) {
-				throw new IllegalArgumentException(context + " missing target species");
+				continue;
 			}
 
 			// Resolve display name to SBML species ID. The user enters a display
 			// name (e.g., "LacI protein") but SBML uses sanitized IDs ("LacI_protein").
 			String speciesId = resolveSpeciesId(sbmlModel, targetSpecies, displayNameToSpeciesId);
-			if (speciesId == null) {
-				throw new IllegalArgumentException(
-						context + " references unknown species '" + targetSpecies + "'");
-			}
+			if (speciesId == null)
+				continue;
 
 			String eventName = getStringParam(simData, SBOLData.PARAM_EVENT_NAME);
 			if (eventName == null || eventName.isEmpty()) {
@@ -805,10 +784,8 @@ public class MxToSBML extends Converter {
 	 */
 	private Species createSpecies(Model model, mxCell glyph) {
 		GlyphInfo glyphInfo = (GlyphInfo) infoDict.get(glyph.getValue());
-		if (glyphInfo == null) {
-			throw new IllegalArgumentException(
-					"No GlyphInfo found for species glyph '" + glyph.getValue() + "' (orphaned glyph?)");
-		}
+		if (glyphInfo == null)
+			return null;
 
 		// SBML ID becomes the label. Pick Name over DisplayID
 		String displayName = glyphInfo.getDisplayID();
@@ -877,13 +854,11 @@ public class MxToSBML extends Converter {
 	 */
 	private void createDegradationReaction(Model model, mxCell edge, InteractionInfo info, mxGraphModel graphModel) {
 		mxCell source = (mxCell) edge.getSource();
-		if (source == null) {
-			throw new IllegalArgumentException("Degradation edge has no source cell (disconnected edge)");
-		}
+		if (source == null)
+			return;
 		SpeciesData sourceData = glyphToSpeciesData.get((String) source.getValue());
-		if (sourceData == null) {
-			throw new IllegalArgumentException("Source species not found for degradation edge");
-		}
+		if (sourceData == null)
+			return;
 
 		String speciesId = sourceData.species.getId();
 		String reactionId = "Degradation_" + speciesId;
@@ -903,7 +878,8 @@ public class MxToSBML extends Converter {
 			law.setMath(new FormulaParser(
 					new ByteArrayInputStream(("kd * " + speciesId).getBytes(StandardCharsets.UTF_8))).parse());
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to parse degradation kinetic law: " + e.getMessage(), e);
+			System.err.println("Warning: degradation formula parse failed for " + speciesId + ": " + e.getMessage());
+			return;
 		}
 	}
 
@@ -916,19 +892,16 @@ public class MxToSBML extends Converter {
 	private void createComplexFormationReaction(Model model, mxCell node, InteractionInfo info,
 			mxGraphModel graphModel) {
 		Object[] outgoing = mxGraphModel.getOutgoingEdges(graphModel, node);
-		if (outgoing.length == 0) {
-			throw new IllegalArgumentException("Complex formation node has no product edge");
-		}
+		if (outgoing.length == 0)
+			return;
 
 		mxCell outEdge = (mxCell) outgoing[0];
 		mxCell target = (mxCell) outEdge.getTarget();
-		if (target == null) {
-			throw new IllegalArgumentException("Complex formation product edge has no target cell (disconnected edge)");
-		}
+		if (target == null)
+			return;
 		SpeciesData productData = glyphToSpeciesData.get((String) target.getValue());
-		if (productData == null) {
-			throw new IllegalArgumentException("Product species not found for complex formation");
-		}
+		if (productData == null)
+			return;
 
 		String productId = productData.species.getId();
 		String reactionId = "Complex_" + productId;
@@ -945,13 +918,11 @@ public class MxToSBML extends Converter {
 		for (Object obj : incoming) {
 			mxCell inEdge = (mxCell) obj;
 			mxCell source = (mxCell) inEdge.getSource();
-			if (source == null) {
-				throw new IllegalArgumentException("Complex formation reactant edge has no source cell (disconnected edge)");
-			}
+			if (source == null)
+				continue;
 			SpeciesData sourceData = glyphToSpeciesData.get((String) source.getValue());
-			if (sourceData == null) {
-				throw new IllegalArgumentException("Reactant species not found for complex formation edge");
-			}
+			if (sourceData == null)
+				continue;
 
 			String speciesId = sourceData.species.getId();
 			SpeciesReference r = reaction.createReactant(sourceData.species);
@@ -986,27 +957,28 @@ public class MxToSBML extends Converter {
 			law.setMath(new FormulaParser(new ByteArrayInputStream(rateLaw.toString().getBytes(StandardCharsets.UTF_8)))
 					.parse());
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to parse complex formation kinetic law: " + e.getMessage(), e);
+			System.err.println("Warning: complex formation formula parse failed for " + productId + ": " + e.getMessage());
+			return;
 		}
 	}
 
 	/**
 	 * Extracts a double from a value that may be a Number, a numeric String,
-	 * or null. Returns defaultVal for null; throws for non-numeric values.
+	 * or null. Returns defaultVal for null, unparseable strings, or unexpected types.
 	 */
-	private static double extractDouble(Object val, double defaultVal, String context) {
-		if (val == null) return defaultVal;
-		if (val instanceof Number) return ((Number) val).doubleValue();
+	private double extractDouble(Object val, double defaultVal, String context) {
+		if (val == null)
+			return defaultVal;
+		if (val instanceof Number)
+			return ((Number) val).doubleValue();
 		if (val instanceof String) {
 			try {
 				return Double.parseDouble((String) val);
 			} catch (NumberFormatException e) {
-				throw new IllegalArgumentException(
-						"Non-numeric value for " + context + ": '" + val + "'", e);
+				return defaultVal;
 			}
 		}
-		throw new IllegalArgumentException(
-				"Invalid type for " + context + ". Expected number, got: " + val.getClass().getSimpleName());
+		return defaultVal;
 	}
 
 	/**
@@ -1031,7 +1003,8 @@ public class MxToSBML extends Converter {
 	 * Returns null if the key is missing or the value is null.
 	 */
 	private String getStringParam(Hashtable<String, Object> simData, String paramName) {
-		if (simData == null || !simData.containsKey(paramName)) return null;
+		if (simData == null || !simData.containsKey(paramName))
+			return null;
 		Object val = simData.get(paramName);
 		return val != null ? val.toString() : null;
 	}
@@ -1064,29 +1037,21 @@ public class MxToSBML extends Converter {
 			key = SBOLData.interactions.getKey(type);
 		}
 
-		if (key == null) {
-			throw new IllegalArgumentException(
-					"Cannot find default for parameter '" + paramName + "' on " + context + ": unknown type");
-		}
+		if (key == null)
+			return 0.0;
 
 		LinkedHashMap<String, Object> params = SBOLData.getSimulationConfig().get(key);
-		if (params == null) {
-			throw new IllegalArgumentException(
-					"Cannot find default for parameter '" + paramName + "' on " + context +
-							": no simulation config for type '" + key + "'");
-		}
+		if (params == null)
+			return 0.0;
 
 		Object val = params.get(paramName);
-		if (val == null) {
-			throw new IllegalArgumentException(
-					"Missing required parameter '" + paramName + "' on " + context + ". Set this value in the Model tab.");
-		}
+		if (val == null)
+			return 0.0;
 
 		if (val instanceof Number) {
 			return ((Number) val).doubleValue();
 		}
-		throw new IllegalArgumentException(
-				"Invalid default value type for parameter '" + paramName + "' on " + context);
+		return 0.0;
 	}
 
 	/**
@@ -1123,7 +1088,7 @@ public class MxToSBML extends Converter {
 	 *
 	 * @param id The raw ID string
 	 * @return A valid, unique SBML SId
-	 * @see Converter#sanitizeAnnotationKey for XML NCName sanitization (different spec, different rules)
+	 * @see Converter#sanitizeAnnotationKey for XML NCName sanitization (different rules)
 	 */
 	private String sanitizeId(String id) {
 		if (id == null || id.isEmpty()) {

--- a/SBOLCanvasBackend/src/utils/MxToSBML.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBML.java
@@ -385,15 +385,18 @@ public class MxToSBML extends Converter {
 				}
 			}
 
-			if (repressorEdge != null && activatorEdge != null)
+			if (repressorEdge != null && activatorEdge != null) {
+				sbmlModel.removeReaction(reaction);
 				continue;
+			}
 
 			if (repressorEdge != null) {
-				buildRepressionFormula(reaction, promoterId, promoterInfo, repressorEdge);
+				buildRepressionFormula(sbmlModel, reaction, promoterId, promoterInfo, repressorEdge);
 			} else if (activatorEdge != null) {
-				buildActivationFormula(reaction, promoterId, promoterInfo, activatorEdge);
+				buildActivationFormula(sbmlModel, reaction, promoterId, promoterInfo, activatorEdge);
 			} else {
 				// TODO: Add constitutive (unregulated) promoter formula
+				sbmlModel.removeReaction(reaction);
 			}
 		}
 	}
@@ -463,8 +466,12 @@ public class MxToSBML extends Converter {
 	 * Formula:
 	 * (P * ko * (ko_f/ko_r) * nr) / (1 + (ko_f/ko_r) * nr + ((kr_f/kr_r) * R)^nc)
 	 */
-	private void buildRepressionFormula(Reaction reaction, String promoterId, GlyphInfo promoterInfo,
+	private void buildRepressionFormula(Model sbmlModel, Reaction reaction, String promoterId, GlyphInfo promoterInfo,
 			mxCell repressorEdge) {
+		mxCell repCell = (mxCell) repressorEdge.getSource();
+		SpeciesData repData = glyphToSpeciesData.get((String) repCell.getValue());
+		if (repData == null) return;
+
 		KineticLaw law = reaction.createKineticLaw();
 
 		Hashtable<String, Object> promoterSimData = promoterInfo.getSimulationData();
@@ -478,10 +485,6 @@ public class MxToSBML extends Converter {
 		law.createLocalParameter("ko_f").setValue(Ko_f);
 		law.createLocalParameter("ko_r").setValue(Ko_r);
 		law.createLocalParameter("nr").setValue(nr);
-
-		mxCell repCell = (mxCell) repressorEdge.getSource();
-		SpeciesData repData = glyphToSpeciesData.get((String) repCell.getValue());
-		if (repData == null) return;
 		String repId = repData.species.getId();
 
 		InteractionInfo repInfo = (InteractionInfo) interactionDict.get(repressorEdge.getValue());
@@ -507,6 +510,7 @@ public class MxToSBML extends Converter {
 			law.setMath(new FormulaParser(new ByteArrayInputStream(formula.getBytes(StandardCharsets.UTF_8))).parse());
 		} catch (Exception e) {
 			System.err.println("Warning: repression formula parse failed for " + promoterId + ": " + e.getMessage());
+			sbmlModel.removeReaction(reaction);
 		}
 	}
 
@@ -520,8 +524,12 @@ public class MxToSBML extends Converter {
 	 * Parameters:
 	 * kb, ka, ko_f, ko_r, kao_f, kao_r, nr, ka_<actId>_f, ka_<actId>_r, nc_<actId>_a
 	 */
-	private void buildActivationFormula(Reaction reaction, String promoterId, GlyphInfo promoterInfo,
+	private void buildActivationFormula(Model sbmlModel, Reaction reaction, String promoterId, GlyphInfo promoterInfo,
 			mxCell activatorEdge) {
+		mxCell actCell = (mxCell) activatorEdge.getSource();
+		SpeciesData actData = glyphToSpeciesData.get((String) actCell.getValue());
+		if (actData == null) return;
+
 		KineticLaw law = reaction.createKineticLaw();
 
 		Hashtable<String, Object> promoterSimData = promoterInfo.getSimulationData();
@@ -541,10 +549,6 @@ public class MxToSBML extends Converter {
 		law.createLocalParameter("kao_f").setValue(Kao_f);
 		law.createLocalParameter("kao_r").setValue(Kao_r);
 		law.createLocalParameter("nr").setValue(nr);
-
-		mxCell actCell = (mxCell) activatorEdge.getSource();
-		SpeciesData actData = glyphToSpeciesData.get((String) actCell.getValue());
-		if (actData == null) return;
 		String actId = actData.species.getId();
 
 		InteractionInfo actInfo = (InteractionInfo) interactionDict.get(activatorEdge.getValue());
@@ -574,6 +578,7 @@ public class MxToSBML extends Converter {
 			law.setMath(new FormulaParser(new ByteArrayInputStream(formula.getBytes(StandardCharsets.UTF_8))).parse());
 		} catch (Exception e) {
 			System.err.println("Warning: activation formula parse failed for " + promoterId + ": " + e.getMessage());
+			sbmlModel.removeReaction(reaction);
 		}
 	}
 
@@ -879,6 +884,7 @@ public class MxToSBML extends Converter {
 					new ByteArrayInputStream(("kd * " + speciesId).getBytes(StandardCharsets.UTF_8))).parse());
 		} catch (Exception e) {
 			System.err.println("Warning: degradation formula parse failed for " + speciesId + ": " + e.getMessage());
+			model.removeReaction(reaction);
 			return;
 		}
 	}
@@ -958,6 +964,7 @@ public class MxToSBML extends Converter {
 					.parse());
 		} catch (Exception e) {
 			System.err.println("Warning: complex formation formula parse failed for " + productId + ": " + e.getMessage());
+			model.removeReaction(reaction);
 			return;
 		}
 	}
@@ -975,9 +982,11 @@ public class MxToSBML extends Converter {
 			try {
 				return Double.parseDouble((String) val);
 			} catch (NumberFormatException e) {
+				System.err.println("Warning: non-numeric value for " + context + ": '" + val + "', using default " + defaultVal);
 				return defaultVal;
 			}
 		}
+		System.err.println("Warning: unexpected type for " + context + ": " + val.getClass().getSimpleName() + ", using default " + defaultVal);
 		return defaultVal;
 	}
 
@@ -1037,20 +1046,27 @@ public class MxToSBML extends Converter {
 			key = SBOLData.interactions.getKey(type);
 		}
 
-		if (key == null)
+		if (key == null) {
+			System.err.println("Warning: no default for '" + paramName + "' on " + context + ": unknown type, using 0.0");
 			return 0.0;
+		}
 
 		LinkedHashMap<String, Object> params = SBOLData.getSimulationConfig().get(key);
-		if (params == null)
+		if (params == null) {
+			System.err.println("Warning: no default for '" + paramName + "' on " + context + ": no config for type '" + key + "', using 0.0");
 			return 0.0;
+		}
 
 		Object val = params.get(paramName);
-		if (val == null)
+		if (val == null) {
+			System.err.println("Warning: no default for '" + paramName + "' on " + context + ": missing from config, using 0.0");
 			return 0.0;
+		}
 
 		if (val instanceof Number) {
 			return ((Number) val).doubleValue();
 		}
+		System.err.println("Warning: invalid default type for '" + paramName + "' on " + context + ": " + val.getClass().getSimpleName() + ", using 0.0");
 		return 0.0;
 	}
 

--- a/SBOLCanvasBackend/src/utils/MxToSBOL.java
+++ b/SBOLCanvasBackend/src/utils/MxToSBOL.java
@@ -168,7 +168,11 @@ public class MxToSBOL extends Converter {
 				.toArray(mxCell[]::new);
 	
 				for(mxCell glyph: glyphs){
-					createComponentDefinition(document, graph, model, glyph);
+					try {
+						createComponentDefinition(document, graph, model, glyph);
+					} catch (Exception e) {
+						System.err.println("Warning: SBOL export skipped glyph: " + e.getMessage());
+					}
 				}
 
 				if (layoutHelper.getGraphicalLayout(URI.create((String) circuitContainer.getValue())) != null){
@@ -176,7 +180,11 @@ public class MxToSBOL extends Converter {
 				}
 
 				// Create Component Definition for the container itself
-				createComponentDefinition(document, graph, model, circuitContainer);
+				try {
+					createComponentDefinition(document, graph, model, circuitContainer);
+				} catch (Exception e) {
+					System.err.println("Warning: SBOL export skipped container: " + e.getMessage());
+				}
 			}
 		}
 		
@@ -190,12 +198,15 @@ public class MxToSBOL extends Converter {
 			mxCell[] molecularSpecies = Arrays.stream(mxGraphModel.filterCells(viewChildren, molecularSpeciesFilter))
 			.toArray(mxCell[]::new);
 
-			if (viewCell.getStyle().equals(STYLE_MODULE_VIEW) || circuitContainers.length > 1 || molecularSpecies.length > 0) {
-				// module definitions
-				createModuleDefinition(document, graph, model, viewCell);
-			} else {
-				// component definitions
-				attachTextBoxAnnotation(model, viewCell, URI.create(viewCell.getId()));
+			try {
+				if (STYLE_MODULE_VIEW.equals(viewCell.getStyle()) || circuitContainers.length > 1 || molecularSpecies.length > 0) {
+					createModuleDefinition(document, graph, model, viewCell);
+				} else {
+					// component definitions
+					attachTextBoxAnnotation(model, viewCell, URI.create(viewCell.getId()));
+				}
+			} catch (Exception e) {
+				System.err.println("Warning: SBOL export skipped view cell: " + e.getMessage());
 			}
 		}
 		
@@ -209,7 +220,11 @@ public class MxToSBOL extends Converter {
 			for (mxCell cell : cells) {
 				if (handledContainers.contains((String) cell.getValue()))
 					continue;
-				linkComponentDefinition(document, graph, model, cell);
+				try {
+					linkComponentDefinition(document, graph, model, cell);
+				} catch (Exception e) {
+					System.err.println("Warning: SBOL export skipped link: " + e.getMessage());
+				}
 				handledContainers.add((String) cell.getValue());
 			}
 		}
@@ -221,24 +236,39 @@ public class MxToSBOL extends Converter {
 					.toArray(mxCell[]::new);
 			mxCell[] molecularSpecies = Arrays.stream(mxGraphModel.filterCells(viewChildren, molecularSpeciesFilter))
 					.toArray(mxCell[]::new);
-			if (viewCell.getStyle().equals(STYLE_MODULE_VIEW) || circuitContainers.length > 1 || molecularSpecies.length > 0) {
-				// module definitions
-				linkModuleDefinition(document, graph, model, viewCell);
+			if (STYLE_MODULE_VIEW.equals(viewCell.getStyle()) || circuitContainers.length > 1 || molecularSpecies.length > 0) {
+				try {
+					linkModuleDefinition(document, graph, model, viewCell);
+				} catch (Exception e) {
+					System.err.println("Warning: SBOL export skipped link: " + e.getMessage());
+				}
 			}
 		}
 
 		// create the combinatorials
 		for (CombinatorialInfo info : combinatorialDict.values()) {
-			createCombinatorial(document, graph, model, info);
+			try {
+				createCombinatorial(document, graph, model, info);
+			} catch (Exception e) {
+				System.err.println("Warning: SBOL export skipped combinatorial: " + e.getMessage());
+			}
 		}
 
 		// link the combinatorials
 		for (CombinatorialInfo info : combinatorialDict.values()) {
-			linkCombinatorial(document, graph, model, info);
+			try {
+				linkCombinatorial(document, graph, model, info);
+			} catch (Exception e) {
+				System.err.println("Warning: SBOL export skipped combinatorial link: " + e.getMessage());
+			}
 		}
 
 		// write events as GenericTopLevel objects
-		writeEvents(document, graph);
+		try {
+			writeEvents(document, graph);
+		} catch (Exception e) {
+			System.err.println("Warning: SBOL export skipped events: " + e.getMessage());
+		}
 
 		return document;
 	}
@@ -370,7 +400,7 @@ public class MxToSBOL extends Converter {
 		// store extra mxGraph information
 		URI identity = URI.create(glyphInfo.getFullURI());
 		layoutHelper.createGraphicalLayout(identity, glyphInfo.getDisplayID() + "_Layout");
-		if(circuitContainer.getStyle().equals(STYLE_CIRCUIT_CONTAINER)){
+		if(STYLE_CIRCUIT_CONTAINER.equals(circuitContainer.getStyle())){
 			
 			Object[] containerChildren = mxGraphModel.getChildCells(model, circuitContainer, true, false);
 			mxCell backboneCell = (mxCell) mxGraphModel.filterCells(containerChildren, backboneFilter)[0];

--- a/SBOLCanvasFrontend/src/app/graph-helpers.ts
+++ b/SBOLCanvasFrontend/src/app/graph-helpers.ts
@@ -2073,7 +2073,7 @@ export class GraphHelpers extends GraphBase {
         this.graph.getModel().execute(new GraphEdits.infoEdit(cell0, eventInfo, null, GraphBase.EVENT_DICT_INDEX))
     }
 
-    protected getFromEventDict(eventURI: string): EventInfo {
+    public getFromEventDict(eventURI: string): EventInfo {
         const cell0 = this.graph.getModel().getCell(0)
         if (!cell0.value[GraphBase.EVENT_DICT_INDEX]) {
             return null
@@ -2142,7 +2142,7 @@ export class GraphHelpers extends GraphBase {
         this.graph.getModel().execute(new GraphEdits.infoEdit(cell0, info, null, GraphBase.INTERACTION_DICT_INDEX))
     }
 
-    protected getFromInteractionDict(interactionURI: string): InteractionInfo {
+    public getFromInteractionDict(interactionURI: string): InteractionInfo {
         const cell0 = this.graph.getModel().getCell(0)
         return cell0.value[GraphBase.INTERACTION_DICT_INDEX][interactionURI]
     }

--- a/SBOLCanvasFrontend/src/app/graph.service.ts
+++ b/SBOLCanvasFrontend/src/app/graph.service.ts
@@ -70,18 +70,14 @@ export class GraphService extends GraphHelpers {
                     },
                     error: err => {
                         console.error('[GraphService] SBOL export failed:', err)
-                        const message = typeof err.error === 'string' ? err.error : err.message || 'SBOL export failed'
-                        embeddedService.postMessage({
-                            error: { type: 'sbol-export', message: message }
-                        })
                     }
                 })
             }
         })
 
-        // SBML auto-export pipeline (2000ms debounce)
+        // SBML auto-export pipeline (1000ms debounce)
         modelChange$
-        .pipe(debounceTime(2000))
+        .pipe(debounceTime(1000))
         .subscribe(graphXml => {
             if (embeddedService.isAppEmbedded()) {
                 console.debug('[GraphService] Model changed. Sending SBML to parent.')
@@ -91,10 +87,6 @@ export class GraphService extends GraphHelpers {
                     },
                     error: err => {
                         console.error('[GraphService] SBML export failed:', err)
-                        const message = typeof err.error === 'string' ? err.error : err.message || 'SBML export failed'
-                        embeddedService.postMessage({
-                            error: { type: 'sbml-export', message: message }
-                        })
                     }
                 })
             }

--- a/SBOLCanvasFrontend/src/app/home/home.component.ts
+++ b/SBOLCanvasFrontend/src/app/home/home.component.ts
@@ -29,7 +29,7 @@ export class HomeComponent implements OnInit, ComponentCanDeactivate {
   leftBarOpened = true;
 
   constructor(private graphService: GraphService, private titleService: Title, private embeddedService: EmbeddedService) {
-    this.titleService.setTitle('SBOL Canvas');
+    this.titleService.setTitle('SBOLCanvas');
   }
 
   ngOnInit() {

--- a/SBOLCanvasFrontend/src/app/landing-page/landing-page.component.html
+++ b/SBOLCanvasFrontend/src/app/landing-page/landing-page.component.html
@@ -23,10 +23,10 @@
       Biologists often face the challenge of effectively communicating DNA sequences and their behaviors. An increasingly popular solution is SBOL, the Synthetic Biology Open Language. It is a diagram syntax that models genetic systems, allowing for both abstract visualizations and detailed data. Unfortunately, the complexity of creating SBOL documents is limiting this powerful language’s growth. SBOL, while characterized by graphic models, is lacking tools for graphical editing. Until now.
       </p>
       <p class="about-text">
-      SBOL Canvas is an open source web-based graphical editor that opens synthetic biology design to anyone from students to advanced researchers. Users will enjoy a simple interface for creating diagrams that are both artistic and scientific. By interfacing with existing SBOL databases, SBOL Canvas lets users share their designs and easily reference the research of others. This editor significantly lowers SBOL’s barrier to entry, helping it carry synthetic biology to new heights.
+      SBOLCanvas is an open source web-based graphical editor that opens synthetic biology design to anyone from students to advanced researchers. Users will enjoy a simple interface for creating diagrams that are both artistic and scientific. By interfacing with existing SBOL databases, SBOLCanvas lets users share their designs and easily reference the research of others. This editor significantly lowers SBOL’s barrier to entry, helping it carry synthetic biology to new heights.
       </p>
       <p class="about-text">
-        SBOL Canvas is supported in part by the <a href="https://sbolstandard.org/sbol-industrial/" target="_blank">SBOL Industrial Consortium</a>. 
+        SBOLCanvas is supported in part by the <a href="https://sbolstandard.org/sbol-industrial/" target="_blank">SBOL Industrial Consortium</a>. 
         It is currently being developed by those in the Genetic Logic Lab led by Dr. Chris Myers and is part of the Synthetic Biology Data Exchange Group. 
       </p>
     </div>

--- a/SBOLCanvasFrontend/src/app/landing-page/landing-page.component.ts
+++ b/SBOLCanvasFrontend/src/app/landing-page/landing-page.component.ts
@@ -14,7 +14,7 @@ export class LandingPageComponent implements OnInit {
   version = "Development";
 
   constructor(private titleService: Title) {
-    this.titleService.setTitle("SBOL Canvas About");
+    this.titleService.setTitle("SBOLCanvas About");
     this.hash = versions.revision;
     this.version = versions.version;
   }

--- a/SBOLCanvasFrontend/src/app/problems/problems.component.ts
+++ b/SBOLCanvasFrontend/src/app/problems/problems.component.ts
@@ -29,6 +29,8 @@ export class ProblemsComponent {
         // Validation functions
         this.validateCurrentView(warnings, errors)
         this.validateComponents(warnings, errors)
+        this.validateBackbones(warnings)
+        this.validateInteractionsAndEvents(warnings)
         // more here...
 
         // Transpose to separate errors and warnings
@@ -37,7 +39,6 @@ export class ProblemsComponent {
     }
 
     validateCurrentView(warnings: string[], errors: string[]) {
-
         const currentView = this.graphService.getCurrentRoot()
         const children = currentView.children || []
 
@@ -63,6 +64,7 @@ export class ProblemsComponent {
 
     validateComponent(component, warnings: string[], errors: string[]) {
         const info = this.graphService.lookupInfo(component.value)
+        if (!info) return
         const sequence = (info.sequence || '').toUpperCase()
         const version = (info.version || '')
 
@@ -91,5 +93,93 @@ export class ProblemsComponent {
         compliant = !!version.match(versionRegex)
         version && !compliant &&
             warnings.push(`Component '${info.displayID}' has incompliant version: ${version}`)
+    }
+
+    validateBackbones(warnings: string[]) {
+        const currentView = this.graphService.getCurrentRoot()
+        const containers = (currentView.children || []).filter(c => c.isCircuitContainer())
+
+        for (const container of containers) {
+            const children = container.children || []
+            const glyphs = children.filter(c => c.isSequenceFeatureGlyph && c.isSequenceFeatureGlyph())
+
+            if (glyphs.length > 0 && !glyphs.some(g => {
+                const info = this.graphService.lookupInfo(g.value)
+                return info && info.partRole && info.partRole.includes('Promoter')
+            })) {
+                const containerInfo = this.graphService.lookupInfo(container.value)
+                const name = (containerInfo && containerInfo.displayID) || 'unnamed'
+                warnings.push(`Backbone '${name}' has no promoter. Add a Promoter for SBML export.`)
+            }
+        }
+    }
+
+    validateInteractionsAndEvents(warnings: string[]) {
+        const currentView = this.graphService.getCurrentRoot()
+        const directChildren = currentView.children || []
+        const nestedChildren = directChildren.map(c => c.children || []).flat()
+        const allCells = [...directChildren, ...nestedChildren]
+
+        // Disconnected interaction edges
+        const interactions = allCells.filter(c => c.isInteraction && c.isInteraction())
+        const regulationByTarget: { [key: string]: { inhibition: boolean, stimulation: boolean } } = {}
+
+        for (const edge of interactions) {
+            const info = this.graphService.getFromInteractionDict(edge.value)
+            if (!info) continue
+
+            const type = info.interactionType
+            const isDegradation = type === 'Degradation'
+
+            // Degradation edges naturally have no target (species degrades into nothing)
+            if (!edge.source || (!edge.target && !isDegradation)) {
+                warnings.push('Disconnected interaction edge found.')
+                continue
+            }
+            if (type === 'Inhibition' || type === 'Stimulation') {
+                const targetId = edge.target.value || 'unknown'
+                if (!regulationByTarget[targetId])
+                    regulationByTarget[targetId] = { inhibition: false, stimulation: false }
+                if (type === 'Inhibition') regulationByTarget[targetId].inhibition = true
+                if (type === 'Stimulation') regulationByTarget[targetId].stimulation = true
+            }
+        }
+
+        for (const [targetId, reg] of Object.entries(regulationByTarget)) {
+            if (reg.inhibition && reg.stimulation) {
+                const info = this.graphService.lookupInfo(targetId)
+                const name = (info && info.name) || (info && info.displayID) || 'unknown'
+                warnings.push(`Mixed regulation on promoter '${name}' - not supported for SBML export.`)
+            }
+        }
+
+        // Complex formation nodes
+        const interactionNodes = allCells.filter(c => c.isInteractionNode && c.isInteractionNode())
+        for (const node of interactionNodes) {
+            const info = this.graphService.getFromInteractionDict(node.value)
+            if (!info) continue
+            const type = info.interactionType
+            if (type !== 'Biochemical Reaction' && type !== 'Non-Covalent Binding') continue
+
+            const edges = this.graphService.graph.getModel().getEdges(node) || []
+            const outgoing = edges.filter(e => e.source === node)
+            if (outgoing.length === 0 || !outgoing[0].target)
+                warnings.push('Complex formation node is missing a product connection.')
+
+            for (const inEdge of edges.filter(e => e.target === node)) {
+                if (!inEdge.source)
+                    warnings.push('Complex formation has a disconnected reactant edge.')
+            }
+        }
+
+        // Events without target species
+        const events = allCells.filter(c => c.isEvent && c.isEvent())
+        for (const event of events) {
+            const eventInfo = this.graphService.getFromEventDict(event.value)
+            if (!eventInfo) continue
+            const targetSpecies = (eventInfo.simulationData || {})['targetSpecies']
+            if (!targetSpecies)
+                warnings.push(`Event '${eventInfo.displayID || 'unnamed'}' has no target species.`)
+        }
     }
 }

--- a/SBOLCanvasFrontend/src/app/problems/problems.component.ts
+++ b/SBOLCanvasFrontend/src/app/problems/problems.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core'
+import { Component, OnDestroy } from '@angular/core'
 import { GraphService } from '../graph.service'
 
 
@@ -8,10 +8,11 @@ import { GraphService } from '../graph.service'
     styleUrls: ['./problems.component.css']
 })
 
-export class ProblemsComponent {
+export class ProblemsComponent implements OnDestroy {
 
     warnings: string[]
     errors: string[]
+    private intervalId: number
 
     constructor(private graphService: GraphService) { }
 
@@ -19,7 +20,11 @@ export class ProblemsComponent {
         this.warnings = []
         this.errors = []
 
-        setInterval(this.validate.bind(this), 750)
+        this.intervalId = window.setInterval(this.validate.bind(this), 750)
+    }
+
+    ngOnDestroy() {
+        clearInterval(this.intervalId)
     }
 
     validate() {

--- a/SBOLCanvasFrontend/src/app/problems/problems.component.ts
+++ b/SBOLCanvasFrontend/src/app/problems/problems.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy } from '@angular/core'
+import { Component, OnDestroy, OnInit } from '@angular/core'
 import { GraphService } from '../graph.service'
 
 
@@ -8,7 +8,7 @@ import { GraphService } from '../graph.service'
     styleUrls: ['./problems.component.css']
 })
 
-export class ProblemsComponent implements OnDestroy {
+export class ProblemsComponent implements OnInit, OnDestroy {
 
     warnings: string[]
     errors: string[]
@@ -114,7 +114,7 @@ export class ProblemsComponent implements OnDestroy {
             })) {
                 const containerInfo = this.graphService.lookupInfo(container.value)
                 const name = (containerInfo && containerInfo.displayID) || 'unnamed'
-                warnings.push(`Backbone '${name}' has no promoter. Add a Promoter for SBML export.`)
+                warnings.push(`Backbone '${name}': no promoter (skipped in SBML)`)
             }
         }
     }
@@ -138,7 +138,11 @@ export class ProblemsComponent implements OnDestroy {
 
             // Degradation edges naturally have no target (species degrades into nothing)
             if (!edge.source || (!edge.target && !isDegradation)) {
-                warnings.push('Disconnected interaction edge found.')
+                const connectedEnd = edge.source || edge.target
+                const endInfo = connectedEnd ? this.graphService.lookupInfo(connectedEnd.value) : null
+                const endName = (endInfo && (endInfo.name || endInfo.displayID)) || 'unknown'
+                const missing = !edge.source ? 'no source' : 'no target'
+                warnings.push(`${type} edge on '${endName}': ${missing}`)
                 continue
             }
             if (type === 'Inhibition' || type === 'Stimulation') {
@@ -154,7 +158,7 @@ export class ProblemsComponent implements OnDestroy {
             if (reg.inhibition && reg.stimulation) {
                 const info = this.graphService.lookupInfo(targetId)
                 const name = (info && info.name) || (info && info.displayID) || 'unknown'
-                warnings.push(`Mixed regulation on promoter '${name}' - not supported for SBML export.`)
+                warnings.push(`Promoter '${name}': mixed regulation (skipped in SBML)`)
             }
         }
 
@@ -167,13 +171,23 @@ export class ProblemsComponent implements OnDestroy {
             if (type !== 'Biochemical Reaction' && type !== 'Non-Covalent Binding') continue
 
             const edges = this.graphService.graph.getModel().getEdges(node) || []
+            const incoming = edges.filter(e => e.target === node)
             const outgoing = edges.filter(e => e.source === node)
-            if (outgoing.length === 0 || !outgoing[0].target)
-                warnings.push('Complex formation node is missing a product connection.')
 
-            for (const inEdge of edges.filter(e => e.target === node)) {
+            const reactantNames = incoming
+                .filter(e => e.source)
+                .map(e => {
+                    const ri = this.graphService.lookupInfo(e.source.value)
+                    return (ri && (ri.name || ri.displayID)) || '?'
+                })
+                .join(', ') || 'none'
+
+            if (outgoing.length === 0 || !outgoing[0].target)
+                warnings.push(`Complex formation (${reactantNames}): no product connection`)
+
+            for (const inEdge of incoming) {
                 if (!inEdge.source)
-                    warnings.push('Complex formation has a disconnected reactant edge.')
+                    warnings.push(`Complex formation (${reactantNames}): disconnected reactant edge`)
             }
         }
 
@@ -184,7 +198,7 @@ export class ProblemsComponent implements OnDestroy {
             if (!eventInfo) continue
             const targetSpecies = (eventInfo.simulationData || {})['targetSpecies']
             if (!targetSpecies)
-                warnings.push(`Event '${eventInfo.displayID || 'unnamed'}' has no target species.`)
+                warnings.push(`Event '${eventInfo.displayID || 'unnamed'}': no target species`)
         }
     }
 }

--- a/SBOLCanvasFrontend/src/app/toolbar/toolbar.component.html
+++ b/SBOLCanvasFrontend/src/app/toolbar/toolbar.component.html
@@ -64,10 +64,10 @@
             <!--    Help menu-->
             <button mat-stroked-button class="toolbar-row-button" [matMenuTriggerFor]="helpMenu">Help</button>
             <mat-menu #helpMenu="matMenu">
-                <button mat-menu-item class="toolbar-row-button" [matTooltip]="'Help using SBOL Canvas'"
+                <button mat-menu-item class="toolbar-row-button" [matTooltip]="'Help using SBOLCanvas'"
                     onClick="window.open('./tutorial')">Tutorial</button>
 
-                <button mat-menu-item class="toolbar-row-button" [matTooltip]="'About SBOL Canavs and its creators'"
+                <button mat-menu-item class="toolbar-row-button" [matTooltip]="'About SBOLCanvas and its creators'"
                     onClick="window.open('./about')">About</button>
 
                 <button mat-menu-item class="toolbar-row-button" [matTooltip]="'Links to Github issue tracker.'"

--- a/SBOLCanvasFrontend/src/app/tutorial/tutorial.component.html
+++ b/SBOLCanvasFrontend/src/app/tutorial/tutorial.component.html
@@ -21,7 +21,7 @@
     <ul style="padding-left:25px">
 
       <li title="Tutorial">
-        <a href="/tutorial#SBOLCanvas">SBOL Canvas</a>
+        <a href="/tutorial#SBOLCanvas">SBOLCanvas</a>
       </li>
 
       <li title="Getting Started">
@@ -59,12 +59,12 @@
   <mat-card-content fxLayout="row wrap" fxLayoutAlign="space-around center">
     <div style="max-width: 1200px;">
       <p class="about-text">
-        SBOL Canvas is the newest tool for creating SBOL documents.
+        SBOLCanvas is the newest tool for creating SBOL documents.
         For an in-depth guide to SBOL structure and syntax, go to <a href="https://sbolstandard.org/">sbolstandard.org</a>.
-        During development, SBOL Canvas's designers drew inspiration from <a href="https://sboldesigner.github.io/">SBOL Designer</a> and <a href="https://draw.io">Draw.io</a>, so it's workflow should be intuitive for anyone familiar with those editors.
+        During development, SBOLCanvas's designers drew inspiration from <a href="https://sboldesigner.github.io/">SBOL Designer</a> and <a href="https://draw.io">Draw.io</a>, so it's workflow should be intuitive for anyone familiar with those editors.
       </p>
       <p class="about-text">
-        SBOL Canavas's <a [routerLink]="['/']">main page</a> is divided into four parts.
+        SBOLCanvas's <a [routerLink]="['/']">main page</a> is divided into four parts.
       </p>
       <ul class="about-text">
         <li>
@@ -86,7 +86,7 @@
           Note that both of these menus are empty unless a valid part is selected on the <b>canvas.</b>
         </li>
       </ul>
-      <p class="about-text">Most of SBOL Canvas's UI elements have a tooltip. Move the mouse over buttons or text fields to see a brief description.</p>
+      <p class="about-text">Most of SBOLCanvas's UI elements have a tooltip. Move the mouse over buttons or text fields to see a brief description.</p>
 
 
       <h2 id="gettingStarted">
@@ -159,7 +159,7 @@
           <br>
           <img src="assets/tutorial_pics/EditingParts/simple_toolbar_options.png" />
           <br>
-          These are controls for zooming in and out of the <b>canavs,</b> deleting the selected components, undoing/redoing recent changes, flipping parts/interactions, bringing elements to the front/back, and entering/exiting parts.
+          These are controls for zooming in and out of the <b>canvas,</b> deleting the selected components, undoing/redoing recent changes, flipping parts/interactions, bringing elements to the front/back, and entering/exiting parts.
           Deleting glyphs can also be done with the "delete" and "backspace" keys on your keyboard, and undoing/redoing can be done with CTRL+Z and CTRL+SHIFT+Z respectively.
         </li>
         <li>

--- a/SBOLCanvasFrontend/src/app/tutorial/tutorial.component.ts
+++ b/SBOLCanvasFrontend/src/app/tutorial/tutorial.component.ts
@@ -9,7 +9,7 @@ import { Title } from '@angular/platform-browser';
 export class TutorialComponent implements OnInit {
 
   constructor(private titleService: Title) {
-    this.titleService.setTitle('SBOL Canvas Tutorial');
+    this.titleService.setTitle('SBOLCanvas Tutorial');
    }
 
   ngOnInit() {

--- a/resources/server_automation/deploy_all.sh
+++ b/resources/server_automation/deploy_all.sh
@@ -9,4 +9,4 @@ ensure_superuser
 ./deploy_backend.sh || die "Backend deployment failed"
 ./deploy_frontend.sh || die "Frontend deployment failed"
 
-echo "SBOL Canvas successfully deployed!"
+echo "SBOLCanvas successfully deployed!"


### PR DESCRIPTION
Export errors during auto-save created a stream of toast notifications in SynBioSuite.

- Backend (`MxToSBML.java`, `MxToSBOL.java`) skips incomplete elements (missing promoters, disconnected edges, null species) and logs to stderr instead of throwing
- Frontend `ProblemsComponent` checks for the same conditions and shows warnings in the Problems dropdown
- Removed error `postMessage` from auto-export sending all the toast notifications to SynBioSuite
- Fixed `setInterval` leak in `ProblemsComponent`, timer was never cleared on destroy
- Fixed SBML parameter names from `kr_f_<id>` to `kr_<id>_f` to match iBioSim
- Reduced SBML auto-export debounce from 2000ms to 1000ms