### PR TITLE
Handle roleless SBOL2 components during import

### DIFF
--- a/SBOLCanvasBackend/src/main/java/org/sbolcanvas/servlets/Convert.java
+++ b/SBOLCanvasBackend/src/main/java/org/sbolcanvas/servlets/Convert.java
@@ -84,7 +84,7 @@ public class Convert extends HttpServlet {
 		} catch (SBOLValidationException | IOException | SBOLConversionException | ParserConfigurationException
 				| TransformerException | SAXException | TransformerFactoryConfigurationError | URISyntaxException | SynBioHubException | javax.xml.stream.XMLStreamException e) {
 			ServletOutputStream outputStream = response.getOutputStream();
-			String message = e.getMessage() != null ? e.getMessage() : "Export failed";
+			String message = errorMessage(e);
 			InputStream inputStream = new ByteArrayInputStream(message.getBytes());
 			IOUtils.copy(inputStream, outputStream);
 
@@ -92,7 +92,7 @@ public class Convert extends HttpServlet {
 			e.printStackTrace();
 		} catch (RuntimeException e) {
 			// Catch unchecked exceptions from SBML export
-			String message = e.getMessage() != null ? e.getMessage() : "Export failed";
+			String message = errorMessage(e);
 			ServletOutputStream outputStream = response.getOutputStream();
 			InputStream inputStream = new ByteArrayInputStream(message.getBytes());
 			IOUtils.copy(inputStream, outputStream);
@@ -100,6 +100,11 @@ public class Convert extends HttpServlet {
 			response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
 			e.printStackTrace();
 		}
+	}
+
+	private static String errorMessage(Throwable e) {
+		String message = e.getMessage();
+		return message != null ? e.getClass().getSimpleName() + ": " + message : e.getClass().getSimpleName();
 	}
 
 }

--- a/SBOLCanvasBackend/src/main/java/org/sbolcanvas/utils/SBOLToMx.java
+++ b/SBOLCanvasBackend/src/main/java/org/sbolcanvas/utils/SBOLToMx.java
@@ -384,7 +384,7 @@ public class SBOLToMx extends Converter {
 		// Check if a circular backbone is present, if so add a duplicate for the right end in SBOLCanvas
 		for (Component glyph : newList) {
 			ComponentDefinition cd = glyph.getDefinition();
-			if (cd != null && cd.getRoles().iterator().next().equals(SBOLData.roles.getValue("Cir (Circular Backbone)"))) {
+			if (cd != null && cd.getRoles().contains(SBOLData.roles.getValue("Cir (Circular Backbone)"))) {
 				duplicateToAdd = glyph;
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes an SBOL2 import failure path where SBOLCanvas assumes every `ComponentDefinition` has at least one role.

## Root Cause

`SBOLToMx.java` checked for circular-backbone components by calling:

```java
cd.getRoles().iterator().next()
```

Valid SBOL2 `ComponentDefinition` objects may legally have an empty role set. When a roleless component is imported, such as a generic GenBank `misc_feature` annotation, this can throw `NoSuchElementException` and cause Canvas import to fail.

`Convert.java` then hid unchecked exceptions without messages behind the generic response `Export failed`, making the real import failure difficult to diagnose.

## Changes

- Replaced the first-role lookup with a safe membership check using `cd.getRoles().contains(...)`.
- Added a small `errorMessage(Throwable e)` helper so conversion failures include the exception class, even when the exception message is null.

## Impact

This makes SBOL2 import robust for standards-valid roleless components and also correctly detects circular-backbone roles when a component has multiple roles and the circular role is not first.

## Validation

- `git diff --check` passed.
- Backend Maven tests Passed (Tests run: 67)

## Notes

SeqTrainer has a workaround that assigns generic Sequence Ontology role `SO:0000110` (`sequence_feature`) to source features without a narrower mapping, but Canvas should still handle roleless valid SBOL2 components safely.